### PR TITLE
docs: add logo to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/atgora-forum/.github/main/assets/logo.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/atgora-forum/.github/main/assets/logo.svg">
+  <img align="right" alt="ATgora Logo" src="https://raw.githubusercontent.com/atgora-forum/.github/main/assets/logo.svg" width="96">
+</picture>
+
 # atgora-api
 
 **AppView backend for ATgora forums**


### PR DESCRIPTION
Adds ATgora logo (96px, top-right) that adapts to GitHub's dark/light theme.