### PR TITLE
feat(api): add full-text and semantic search (M8)

### DIFF
--- a/drizzle/0010_dear_phil_sheldon.sql
+++ b/drizzle/0010_dear_phil_sheldon.sql
@@ -1,0 +1,58 @@
+-- M8: Full-text search + optional semantic search
+-- Drops placeholder text embedding columns and replaces with proper types.
+-- Adds pgvector extension, tsvector search columns, GIN/HNSW indexes, and triggers.
+
+-- Remove placeholder text embedding columns (no data exists yet)
+ALTER TABLE "topics" DROP COLUMN IF EXISTS "embedding";--> statement-breakpoint
+ALTER TABLE "replies" DROP COLUMN IF EXISTS "embedding";--> statement-breakpoint
+
+-- Install pgvector extension for semantic search
+CREATE EXTENSION IF NOT EXISTS vector;--> statement-breakpoint
+
+-- Add tsvector columns for full-text search
+ALTER TABLE "topics" ADD COLUMN "search_vector" tsvector;--> statement-breakpoint
+ALTER TABLE "replies" ADD COLUMN "search_vector" tsvector;--> statement-breakpoint
+
+-- Add vector columns for semantic search (nullable -- only populated when EMBEDDING_URL configured)
+ALTER TABLE "topics" ADD COLUMN "embedding" vector(768);--> statement-breakpoint
+ALTER TABLE "replies" ADD COLUMN "embedding" vector(768);--> statement-breakpoint
+
+-- GIN indexes for full-text search performance
+CREATE INDEX "topics_search_vector_idx" ON "topics" USING gin ("search_vector");--> statement-breakpoint
+CREATE INDEX "replies_search_vector_idx" ON "replies" USING gin ("search_vector");--> statement-breakpoint
+
+-- HNSW indexes for vector similarity search performance
+CREATE INDEX "topics_embedding_idx" ON "topics" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+CREATE INDEX "replies_embedding_idx" ON "replies" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+
+-- Trigger function: auto-update topics search_vector on insert/update
+-- Title weighted A (highest), content weighted B
+CREATE OR REPLACE FUNCTION update_topic_search_vector()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE TRIGGER topic_search_vector_update
+  BEFORE INSERT OR UPDATE OF title, content ON topics
+  FOR EACH ROW
+  EXECUTE FUNCTION update_topic_search_vector();--> statement-breakpoint
+
+-- Trigger function: auto-update replies search_vector on insert/update
+CREATE OR REPLACE FUNCTION update_reply_search_vector()
+RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    to_tsvector('english', COALESCE(NEW.content, ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+
+CREATE TRIGGER reply_search_vector_update
+  BEFORE INSERT OR UPDATE OF content ON replies
+  FOR EACH ROW
+  EXECUTE FUNCTION update_reply_search_vector();

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1273 @@
+{
+  "id": "38f94dc1-1f3f-4ecc-8d82-4e4520cff5cb",
+  "prevId": "6885ca86-2577-4da3-b6dd-8b84c2267aa6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_score": {
+          "name": "reputation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "age_declared_at": {
+          "name": "age_declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturity_pref": {
+          "name": "maturity_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firehose_cursor": {
+      "name": "firehose_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_mod_deleted": {
+          "name": "is_mod_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "topics_author_did_idx": {
+          "name": "topics_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_category_idx": {
+          "name": "topics_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_created_at_idx": {
+          "name": "topics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_last_activity_at_idx": {
+          "name": "topics_last_activity_at_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_community_did_idx": {
+          "name": "topics_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replies": {
+      "name": "replies",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cid": {
+          "name": "root_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_uri": {
+          "name": "parent_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_cid": {
+          "name": "parent_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replies_author_did_idx": {
+          "name": "replies_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_root_uri_idx": {
+          "name": "replies_root_uri_idx",
+          "columns": [
+            {
+              "expression": "root_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_parent_uri_idx": {
+          "name": "replies_parent_uri_idx",
+          "columns": [
+            {
+              "expression": "parent_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_created_at_idx": {
+          "name": "replies_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_community_did_idx": {
+          "name": "replies_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_cid": {
+          "name": "subject_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_author_did_idx": {
+          "name": "reactions_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_subject_uri_idx": {
+          "name": "reactions_subject_uri_idx",
+          "columns": [
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_community_did_idx": {
+          "name": "reactions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_author_subject_type_uniq": {
+          "name": "reactions_author_subject_type_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_did",
+            "subject_uri",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tracked_at": {
+          "name": "tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "initialized": {
+          "name": "initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_did": {
+          "name": "admin_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_name": {
+          "name": "community_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Barazo Community'"
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "reaction_set": {
+          "name": "reaction_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"like\"]'::jsonb"
+        },
+        "moderation_thresholds": {
+          "name": "moderation_thresholds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"autoBlockReportCount\":5,\"warnThreshold\":3}'::jsonb"
+        },
+        "word_filter": {
+          "name": "word_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_community_did_idx": {
+          "name": "categories_slug_community_did_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_parent_id_idx": {
+          "name": "categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_community_did_idx": {
+          "name": "categories_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_maturity_rating_idx": {
+          "name": "categories_maturity_rating_idx",
+          "columns": [
+            {
+              "expression": "maturity_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_fk": {
+          "name": "categories_parent_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_did": {
+          "name": "moderator_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_actions_moderator_did_idx": {
+          "name": "mod_actions_moderator_did_idx",
+          "columns": [
+            {
+              "expression": "moderator_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_community_did_idx": {
+          "name": "mod_actions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_created_at_idx": {
+          "name": "mod_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_uri_idx": {
+          "name": "mod_actions_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_did_idx": {
+          "name": "mod_actions_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_did": {
+          "name": "reporter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_type": {
+          "name": "reason_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution_type": {
+          "name": "resolution_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_reporter_did_idx": {
+          "name": "reports_reporter_did_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_uri_idx": {
+          "name": "reports_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_did_idx": {
+          "name": "reports_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_community_did_idx": {
+          "name": "reports_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_unique_reporter_target_idx": {
+          "name": "reports_unique_reporter_target_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1771036272209,
       "tag": "0009_chemical_dakota_north",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1771036752885,
+      "tag": "0010_dear_phil_sheldon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import { categoryRoutes } from "./routes/categories.js";
 import { adminSettingsRoutes } from "./routes/admin-settings.js";
 import { reactionRoutes } from "./routes/reactions.js";
 import { moderationRoutes } from "./routes/moderation.js";
+import { searchRoutes } from "./routes/search.js";
 import { createRequireAdmin } from "./auth/require-admin.js";
 import { createSetupService } from "./setup/service.js";
 import type { SetupService } from "./setup/service.js";
@@ -191,6 +192,7 @@ export async function buildApp(env: Env) {
   await app.register(adminSettingsRoutes());
   await app.register(reactionRoutes());
   await app.register(moderationRoutes());
+  await app.register(searchRoutes());
 
   // OpenAPI spec endpoint (after routes so all schemas are registered)
   app.get("/api/openapi.json", { schema: { hide: true } }, async (_request, reply) => {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -60,6 +60,11 @@ export const envSchema = z.object({
 
   // Optional: semantic search
   EMBEDDING_URL: z.string().optional(),
+  AI_EMBEDDING_DIMENSIONS: z
+    .string()
+    .default("768")
+    .transform((val) => Number(val))
+    .pipe(z.number().int().min(384).max(1536)),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/db/schema/replies.ts
+++ b/src/db/schema/replies.ts
@@ -27,7 +27,10 @@ export const replies = pgTable(
     indexedAt: timestamp("indexed_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
-    embedding: text("embedding"),
+    // Note: search_vector (tsvector) and embedding (vector) columns exist in the
+    // database but are managed outside Drizzle schema (see migration 0010).
+    // search_vector is maintained by a database trigger.
+    // embedding is nullable vector(768) for optional semantic search.
   },
   (table) => [
     index("replies_author_did_idx").on(table.authorDid),

--- a/src/db/schema/topics.ts
+++ b/src/db/schema/topics.ts
@@ -34,7 +34,10 @@ export const topics = pgTable(
     isLocked: boolean("is_locked").notNull().default(false),
     isPinned: boolean("is_pinned").notNull().default(false),
     isModDeleted: boolean("is_mod_deleted").notNull().default(false),
-    embedding: text("embedding"),
+    // Note: search_vector (tsvector) and embedding (vector) columns exist in the
+    // database but are managed outside Drizzle schema (see migration 0010).
+    // search_vector is maintained by a database trigger.
+    // embedding is nullable vector(768) for optional semantic search.
   },
   (table) => [
     index("topics_author_did_idx").on(table.authorDid),

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,0 +1,737 @@
+import { sql } from "drizzle-orm";
+import type { FastifyPluginCallback } from "fastify";
+import { badRequest } from "../lib/api-errors.js";
+import { createEmbeddingService } from "../services/embedding.js";
+import { searchQuerySchema } from "../validation/search.js";
+import type { Database } from "../db/index.js";
+
+// ---------------------------------------------------------------------------
+// OpenAPI JSON Schema definitions
+// ---------------------------------------------------------------------------
+
+const searchResultJsonSchema = {
+  type: "object" as const,
+  properties: {
+    type: { type: "string" as const, enum: ["topic", "reply"] },
+    uri: { type: "string" as const },
+    rkey: { type: "string" as const },
+    authorDid: { type: "string" as const },
+    title: { type: ["string", "null"] as const },
+    content: { type: "string" as const },
+    category: { type: ["string", "null"] as const },
+    communityDid: { type: "string" as const },
+    replyCount: { type: ["integer", "null"] as const },
+    reactionCount: { type: "integer" as const },
+    createdAt: { type: "string" as const, format: "date-time" as const },
+    rank: { type: "number" as const },
+    rootUri: { type: ["string", "null"] as const },
+    rootTitle: { type: ["string", "null"] as const },
+  },
+};
+
+const errorJsonSchema = {
+  type: "object" as const,
+  properties: {
+    error: { type: "string" as const },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TopicSearchRow {
+  [key: string]: unknown;
+  uri: string;
+  rkey: string;
+  author_did: string;
+  title: string;
+  content: string;
+  category: string;
+  community_did: string;
+  reply_count: number;
+  reaction_count: number;
+  created_at: Date;
+  rank: number;
+}
+
+interface ReplySearchRow {
+  [key: string]: unknown;
+  uri: string;
+  rkey: string;
+  author_did: string;
+  content: string;
+  community_did: string;
+  reaction_count: number;
+  created_at: Date;
+  root_uri: string;
+  root_title: string | null;
+  rank: number;
+}
+
+interface CountRow {
+  [key: string]: unknown;
+  count: string;
+}
+
+interface SearchResultItem {
+  type: "topic" | "reply";
+  uri: string;
+  rkey: string;
+  authorDid: string;
+  title: string | null;
+  content: string;
+  category: string | null;
+  communityDid: string;
+  replyCount: number | null;
+  reactionCount: number;
+  createdAt: string;
+  rank: number;
+  rootUri: string | null;
+  rootTitle: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a text snippet from content. Returns first ~300 characters,
+ * truncating at a word boundary when possible.
+ */
+function createSnippet(content: string, maxLength = 300): string {
+  if (content.length <= maxLength) {
+    return content;
+  }
+  return content.slice(0, maxLength) + "...";
+}
+
+/**
+ * Encode a search cursor from rank + uri.
+ */
+function encodeCursor(rank: number, uri: string): string {
+  return Buffer.from(JSON.stringify({ rank, uri })).toString("base64");
+}
+
+/**
+ * Decode a search cursor. Returns null if invalid.
+ */
+function decodeCursor(
+  cursor: string,
+): { rank: number; uri: string } | null {
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(cursor, "base64").toString("utf-8"),
+    ) as Record<string, unknown>;
+    if (typeof decoded.rank === "number" && typeof decoded.uri === "string") {
+      return { rank: decoded.rank, uri: decoded.uri };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge full-text and vector search results using Reciprocal Rank Fusion.
+ * RRF formula: score = sum(1 / (k + rank_i)) for each ranking system.
+ * k=60 is the standard constant to prevent top-ranked items from dominating.
+ */
+function reciprocalRankFusion(
+  fulltextResults: SearchResultItem[],
+  vectorResults: SearchResultItem[],
+  k = 60,
+): SearchResultItem[] {
+  const scores = new Map<string, { score: number; item: SearchResultItem }>();
+
+  // Score full-text results by their position (rank = position, 1-indexed)
+  for (let i = 0; i < fulltextResults.length; i++) {
+    const item = fulltextResults[i];
+    if (!item) continue;
+    const rrfScore = 1.0 / (k + i + 1);
+    scores.set(item.uri, { score: rrfScore, item });
+  }
+
+  // Score vector results by their position
+  for (let i = 0; i < vectorResults.length; i++) {
+    const item = vectorResults[i];
+    if (!item) continue;
+    const rrfScore = 1.0 / (k + i + 1);
+    const existing = scores.get(item.uri);
+    if (existing) {
+      existing.score += rrfScore;
+    } else {
+      scores.set(item.uri, { score: rrfScore, item });
+    }
+  }
+
+  // Sort by RRF score descending
+  return Array.from(scores.values())
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => ({ ...entry.item, rank: entry.score }));
+}
+
+// ---------------------------------------------------------------------------
+// Search routes plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * Search routes for the Barazo forum.
+ *
+ * - GET /api/search -- Full-text search (with optional semantic/hybrid mode)
+ */
+export function searchRoutes(): FastifyPluginCallback {
+  return (app, _opts, done) => {
+    const { db, env, authMiddleware } = app;
+
+    const embeddingService = createEmbeddingService(
+      env.EMBEDDING_URL,
+      env.AI_EMBEDDING_DIMENSIONS,
+      app.log,
+    );
+
+    // -------------------------------------------------------------------
+    // GET /api/search (public, optionalAuth)
+    // -------------------------------------------------------------------
+
+    app.get("/api/search", {
+      preHandler: [authMiddleware.optionalAuth],
+      schema: {
+        tags: ["Search"],
+        summary: "Search topics and replies",
+        querystring: {
+          type: "object",
+          required: ["q"],
+          properties: {
+            q: { type: "string", minLength: 1, maxLength: 500 },
+            category: { type: "string" },
+            author: { type: "string" },
+            dateFrom: { type: "string", format: "date-time" },
+            dateTo: { type: "string", format: "date-time" },
+            type: {
+              type: "string",
+              enum: ["topics", "replies", "all"],
+              default: "all",
+            },
+            limit: { type: "string" },
+            cursor: { type: "string" },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              results: {
+                type: "array",
+                items: searchResultJsonSchema,
+              },
+              cursor: { type: ["string", "null"] },
+              total: { type: "integer" },
+              searchMode: {
+                type: "string",
+                enum: ["fulltext", "hybrid"],
+              },
+            },
+          },
+          400: errorJsonSchema,
+        },
+      },
+    }, async (request, reply) => {
+      const parsed = searchQuerySchema.safeParse(request.query);
+      if (!parsed.success) {
+        throw badRequest("Invalid search parameters");
+      }
+
+      const {
+        q: query,
+        category,
+        author,
+        dateFrom,
+        dateTo,
+        type: searchType,
+        limit,
+        cursor,
+      } = parsed.data;
+
+      // Parse cursor for pagination
+      let cursorRank: number | undefined;
+      let cursorUri: string | undefined;
+      if (cursor) {
+        const decoded = decodeCursor(cursor);
+        if (decoded) {
+          cursorRank = decoded.rank;
+          cursorUri = decoded.uri;
+        }
+      }
+
+      // Determine search mode
+      let searchMode: "fulltext" | "hybrid" = "fulltext";
+      let queryEmbedding: number[] | null = null;
+
+      if (embeddingService.isEnabled()) {
+        queryEmbedding = await embeddingService.generateEmbedding(query);
+        if (queryEmbedding) {
+          searchMode = "hybrid";
+        }
+      }
+
+      const allResults: SearchResultItem[] = [];
+
+      // -----------------------------------------------------------------
+      // Full-text search: topics
+      // -----------------------------------------------------------------
+      if (searchType === "topics" || searchType === "all") {
+        const topicResults = await searchTopicsFulltext(db, query, {
+          category,
+          author,
+          dateFrom,
+          dateTo,
+          cursorRank,
+          cursorUri,
+        }, limit + 1);
+
+        for (const row of topicResults) {
+          allResults.push({
+            type: "topic",
+            uri: row.uri,
+            rkey: row.rkey,
+            authorDid: row.author_did,
+            title: row.title,
+            content: createSnippet(row.content),
+            category: row.category,
+            communityDid: row.community_did,
+            replyCount: row.reply_count,
+            reactionCount: row.reaction_count,
+            createdAt: row.created_at instanceof Date
+              ? row.created_at.toISOString()
+              : String(row.created_at),
+            rank: row.rank,
+            rootUri: null,
+            rootTitle: null,
+          });
+        }
+      }
+
+      // -----------------------------------------------------------------
+      // Full-text search: replies
+      // -----------------------------------------------------------------
+      if (searchType === "replies" || searchType === "all") {
+        const replyResults = await searchRepliesFulltext(db, query, {
+          author,
+          dateFrom,
+          dateTo,
+          cursorRank,
+          cursorUri,
+        }, limit + 1);
+
+        for (const row of replyResults) {
+          allResults.push({
+            type: "reply",
+            uri: row.uri,
+            rkey: row.rkey,
+            authorDid: row.author_did,
+            title: null,
+            content: createSnippet(row.content),
+            category: null,
+            communityDid: row.community_did,
+            replyCount: null,
+            reactionCount: row.reaction_count,
+            createdAt: row.created_at instanceof Date
+              ? row.created_at.toISOString()
+              : String(row.created_at),
+            rank: row.rank,
+            rootUri: row.root_uri,
+            rootTitle: row.root_title,
+          });
+        }
+      }
+
+      // -----------------------------------------------------------------
+      // Hybrid search: merge with vector results via RRF
+      // -----------------------------------------------------------------
+      let mergedResults: SearchResultItem[];
+
+      if (searchMode === "hybrid" && queryEmbedding) {
+        const vectorResults: SearchResultItem[] = [];
+
+        if (searchType === "topics" || searchType === "all") {
+          const vecTopics = await searchTopicsVector(db, queryEmbedding, {
+            category,
+            author,
+            dateFrom,
+            dateTo,
+          }, limit);
+
+          for (const row of vecTopics) {
+            vectorResults.push({
+              type: "topic",
+              uri: row.uri,
+              rkey: row.rkey,
+              authorDid: row.author_did,
+              title: row.title,
+              content: createSnippet(row.content),
+              category: row.category,
+              communityDid: row.community_did,
+              replyCount: row.reply_count,
+              reactionCount: row.reaction_count,
+              createdAt: row.created_at instanceof Date
+                ? row.created_at.toISOString()
+                : String(row.created_at),
+              rank: row.rank,
+              rootUri: null,
+              rootTitle: null,
+            });
+          }
+        }
+
+        if (searchType === "replies" || searchType === "all") {
+          const vecReplies = await searchRepliesVector(db, queryEmbedding, {
+            author,
+            dateFrom,
+            dateTo,
+          }, limit);
+
+          for (const row of vecReplies) {
+            vectorResults.push({
+              type: "reply",
+              uri: row.uri,
+              rkey: row.rkey,
+              authorDid: row.author_did,
+              title: null,
+              content: createSnippet(row.content),
+              category: null,
+              communityDid: row.community_did,
+              replyCount: null,
+              reactionCount: row.reaction_count,
+              createdAt: row.created_at instanceof Date
+                ? row.created_at.toISOString()
+                : String(row.created_at),
+              rank: row.rank,
+              rootUri: row.root_uri,
+              rootTitle: row.root_title,
+            });
+          }
+        }
+
+        mergedResults = reciprocalRankFusion(allResults, vectorResults);
+      } else {
+        // Full-text only: sort all results by rank descending
+        mergedResults = allResults.sort((a, b) => b.rank - a.rank);
+      }
+
+      // -----------------------------------------------------------------
+      // Pagination
+      // -----------------------------------------------------------------
+      const hasMore = mergedResults.length > limit;
+      const pageResults = hasMore
+        ? mergedResults.slice(0, limit)
+        : mergedResults;
+
+      let nextCursor: string | null = null;
+      if (hasMore) {
+        const lastResult = pageResults[pageResults.length - 1];
+        if (lastResult) {
+          nextCursor = encodeCursor(lastResult.rank, lastResult.uri);
+        }
+      }
+
+      // Count total results (separate query for accurate count)
+      let total = pageResults.length;
+      if (hasMore) {
+        total = await countSearchResults(db, query, {
+          category,
+          author,
+          dateFrom,
+          dateTo,
+          searchType,
+        });
+      }
+
+      return reply.status(200).send({
+        results: pageResults,
+        cursor: nextCursor,
+        total,
+        searchMode,
+      });
+    });
+
+    done();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Database query helpers
+// ---------------------------------------------------------------------------
+
+interface SearchFilters {
+  category?: string | undefined;
+  author?: string | undefined;
+  dateFrom?: string | undefined;
+  dateTo?: string | undefined;
+  cursorRank?: number | undefined;
+  cursorUri?: string | undefined;
+}
+
+/**
+ * Full-text search for topics using PostgreSQL tsvector.
+ */
+async function searchTopicsFulltext(
+  db: Database,
+  query: string,
+  filters: SearchFilters,
+  fetchLimit: number,
+): Promise<TopicSearchRow[]> {
+  const conditions: ReturnType<typeof sql>[] = [
+    sql`search_vector @@ websearch_to_tsquery('english', ${query})`,
+    sql`is_mod_deleted = false`,
+  ];
+
+  if (filters.category) {
+    conditions.push(sql`category = ${filters.category}`);
+  }
+  if (filters.author) {
+    conditions.push(sql`author_did = ${filters.author}`);
+  }
+  if (filters.dateFrom) {
+    conditions.push(sql`created_at >= ${filters.dateFrom}::timestamptz`);
+  }
+  if (filters.dateTo) {
+    conditions.push(sql`created_at <= ${filters.dateTo}::timestamptz`);
+  }
+  if (filters.cursorRank !== undefined && filters.cursorUri) {
+    conditions.push(
+      sql`(ts_rank_cd(search_vector, websearch_to_tsquery('english', ${query})), uri) < (${filters.cursorRank}, ${filters.cursorUri})`,
+    );
+  }
+
+  const whereClause = sql.join(conditions, sql` AND `);
+
+  const result = await db.execute(sql`
+    SELECT
+      uri, rkey, author_did, title, content, category, community_did,
+      reply_count, reaction_count, created_at,
+      ts_rank_cd(search_vector, websearch_to_tsquery('english', ${query})) AS rank
+    FROM topics
+    WHERE ${whereClause}
+    ORDER BY rank DESC, created_at DESC
+    LIMIT ${fetchLimit}
+  `);
+
+  return result as unknown as TopicSearchRow[];
+}
+
+/**
+ * Full-text search for replies using PostgreSQL tsvector.
+ * Joins with topics to provide root topic context.
+ */
+async function searchRepliesFulltext(
+  db: Database,
+  query: string,
+  filters: Omit<SearchFilters, "category">,
+  fetchLimit: number,
+): Promise<ReplySearchRow[]> {
+  const conditions: ReturnType<typeof sql>[] = [
+    sql`r.search_vector @@ websearch_to_tsquery('english', ${query})`,
+  ];
+
+  if (filters.author) {
+    conditions.push(sql`r.author_did = ${filters.author}`);
+  }
+  if (filters.dateFrom) {
+    conditions.push(sql`r.created_at >= ${filters.dateFrom}::timestamptz`);
+  }
+  if (filters.dateTo) {
+    conditions.push(sql`r.created_at <= ${filters.dateTo}::timestamptz`);
+  }
+  if (filters.cursorRank !== undefined && filters.cursorUri) {
+    conditions.push(
+      sql`(ts_rank_cd(r.search_vector, websearch_to_tsquery('english', ${query})), r.uri) < (${filters.cursorRank}, ${filters.cursorUri})`,
+    );
+  }
+
+  const whereClause = sql.join(conditions, sql` AND `);
+
+  const result = await db.execute(sql`
+    SELECT
+      r.uri, r.rkey, r.author_did, r.content, r.community_did,
+      r.reaction_count, r.created_at, r.root_uri,
+      t.title AS root_title,
+      ts_rank_cd(r.search_vector, websearch_to_tsquery('english', ${query})) AS rank
+    FROM replies r
+    LEFT JOIN topics t ON t.uri = r.root_uri
+    WHERE ${whereClause}
+    ORDER BY rank DESC, r.created_at DESC
+    LIMIT ${fetchLimit}
+  `);
+
+  return result as unknown as ReplySearchRow[];
+}
+
+/**
+ * Vector similarity search for topics.
+ * Uses cosine distance operator (<=>).
+ */
+async function searchTopicsVector(
+  db: Database,
+  queryEmbedding: number[],
+  filters: Omit<SearchFilters, "cursorRank" | "cursorUri">,
+  fetchLimit: number,
+): Promise<TopicSearchRow[]> {
+  const embeddingStr = `[${queryEmbedding.join(",")}]`;
+
+  const conditions: ReturnType<typeof sql>[] = [
+    sql`embedding IS NOT NULL`,
+    sql`is_mod_deleted = false`,
+    sql`embedding <=> ${embeddingStr}::vector < 0.5`,
+  ];
+
+  if (filters.category) {
+    conditions.push(sql`category = ${filters.category}`);
+  }
+  if (filters.author) {
+    conditions.push(sql`author_did = ${filters.author}`);
+  }
+  if (filters.dateFrom) {
+    conditions.push(sql`created_at >= ${filters.dateFrom}::timestamptz`);
+  }
+  if (filters.dateTo) {
+    conditions.push(sql`created_at <= ${filters.dateTo}::timestamptz`);
+  }
+
+  const whereClause = sql.join(conditions, sql` AND `);
+
+  const result = await db.execute(sql`
+    SELECT
+      uri, rkey, author_did, title, content, category, community_did,
+      reply_count, reaction_count, created_at,
+      (1.0 - (embedding <=> ${embeddingStr}::vector)) AS rank
+    FROM topics
+    WHERE ${whereClause}
+    ORDER BY embedding <=> ${embeddingStr}::vector ASC
+    LIMIT ${fetchLimit}
+  `);
+
+  return result as unknown as TopicSearchRow[];
+}
+
+/**
+ * Vector similarity search for replies.
+ * Uses cosine distance operator (<=>).
+ */
+async function searchRepliesVector(
+  db: Database,
+  queryEmbedding: number[],
+  filters: Omit<SearchFilters, "category" | "cursorRank" | "cursorUri">,
+  fetchLimit: number,
+): Promise<ReplySearchRow[]> {
+  const embeddingStr = `[${queryEmbedding.join(",")}]`;
+
+  const conditions: ReturnType<typeof sql>[] = [
+    sql`r.embedding IS NOT NULL`,
+    sql`r.embedding <=> ${embeddingStr}::vector < 0.5`,
+  ];
+
+  if (filters.author) {
+    conditions.push(sql`r.author_did = ${filters.author}`);
+  }
+  if (filters.dateFrom) {
+    conditions.push(sql`r.created_at >= ${filters.dateFrom}::timestamptz`);
+  }
+  if (filters.dateTo) {
+    conditions.push(sql`r.created_at <= ${filters.dateTo}::timestamptz`);
+  }
+
+  const whereClause = sql.join(conditions, sql` AND `);
+
+  const result = await db.execute(sql`
+    SELECT
+      r.uri, r.rkey, r.author_did, r.content, r.community_did,
+      r.reaction_count, r.created_at, r.root_uri,
+      t.title AS root_title,
+      (1.0 - (r.embedding <=> ${embeddingStr}::vector)) AS rank
+    FROM replies r
+    LEFT JOIN topics t ON t.uri = r.root_uri
+    WHERE ${whereClause}
+    ORDER BY r.embedding <=> ${embeddingStr}::vector ASC
+    LIMIT ${fetchLimit}
+  `);
+
+  return result as unknown as ReplySearchRow[];
+}
+
+/**
+ * Count total matching results for pagination metadata.
+ */
+async function countSearchResults(
+  db: Database,
+  query: string,
+  filters: {
+    category?: string | undefined;
+    author?: string | undefined;
+    dateFrom?: string | undefined;
+    dateTo?: string | undefined;
+    searchType: "topics" | "replies" | "all";
+  },
+): Promise<number> {
+  let total = 0;
+
+  if (filters.searchType === "topics" || filters.searchType === "all") {
+    const conditions: ReturnType<typeof sql>[] = [
+      sql`search_vector @@ websearch_to_tsquery('english', ${query})`,
+      sql`is_mod_deleted = false`,
+    ];
+
+    if (filters.category) {
+      conditions.push(sql`category = ${filters.category}`);
+    }
+    if (filters.author) {
+      conditions.push(sql`author_did = ${filters.author}`);
+    }
+    if (filters.dateFrom) {
+      conditions.push(sql`created_at >= ${filters.dateFrom}::timestamptz`);
+    }
+    if (filters.dateTo) {
+      conditions.push(sql`created_at <= ${filters.dateTo}::timestamptz`);
+    }
+
+    const whereClause = sql.join(conditions, sql` AND `);
+
+    const result = await db.execute(sql`
+      SELECT COUNT(*) AS count
+      FROM topics
+      WHERE ${whereClause}
+    `);
+
+    const rows = result as unknown as CountRow[];
+    total += Number(rows[0]?.count ?? 0);
+  }
+
+  if (filters.searchType === "replies" || filters.searchType === "all") {
+    const conditions: ReturnType<typeof sql>[] = [
+      sql`search_vector @@ websearch_to_tsquery('english', ${query})`,
+    ];
+
+    if (filters.author) {
+      conditions.push(sql`author_did = ${filters.author}`);
+    }
+    if (filters.dateFrom) {
+      conditions.push(sql`created_at >= ${filters.dateFrom}::timestamptz`);
+    }
+    if (filters.dateTo) {
+      conditions.push(sql`created_at <= ${filters.dateTo}::timestamptz`);
+    }
+
+    const whereClause = sql.join(conditions, sql` AND `);
+
+    const result = await db.execute(sql`
+      SELECT COUNT(*) AS count
+      FROM replies
+      WHERE ${whereClause}
+    `);
+
+    const rows = result as unknown as CountRow[];
+    total += Number(rows[0]?.count ?? 0);
+  }
+
+  return total;
+}

--- a/src/services/embedding.ts
+++ b/src/services/embedding.ts
@@ -1,0 +1,85 @@
+import type { Logger } from "../lib/logger.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EmbeddingService {
+  /** Generate an embedding vector for the given text. Returns null on failure or when disabled. */
+  generateEmbedding(text: string): Promise<number[] | null>;
+  /** Whether the embedding service is configured and available. */
+  isEnabled(): boolean;
+}
+
+/** OpenAI-compatible embedding response. */
+interface EmbeddingResponse {
+  data: ReadonlyArray<{ embedding: number[] }>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an embedding service that calls an OpenAI-compatible embedding API.
+ *
+ * If `embeddingUrl` is undefined or empty, the service operates in disabled mode:
+ * `isEnabled()` returns false and `generateEmbedding()` always returns null.
+ *
+ * On network or API errors the service logs a warning and returns null -- it
+ * never throws. This allows the search route to gracefully degrade to
+ * full-text-only search when the embedding backend is unavailable.
+ */
+export function createEmbeddingService(
+  embeddingUrl: string | undefined,
+  dimensions: number,
+  logger: Logger,
+): EmbeddingService {
+  const enabled = typeof embeddingUrl === "string" && embeddingUrl.length > 0;
+
+  return {
+    isEnabled(): boolean {
+      return enabled;
+    },
+
+    async generateEmbedding(text: string): Promise<number[] | null> {
+      if (!enabled || !embeddingUrl) {
+        return null;
+      }
+
+      try {
+        const response = await fetch(embeddingUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            input: text,
+            model: "default",
+            dimensions,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (!response.ok) {
+          logger.warn(
+            { status: response.status, url: embeddingUrl },
+            "Embedding API returned non-OK status",
+          );
+          return null;
+        }
+
+        const body = (await response.json()) as EmbeddingResponse;
+        const embedding = body.data[0]?.embedding;
+
+        if (!Array.isArray(embedding) || embedding.length === 0) {
+          logger.warn("Embedding API returned empty or invalid embedding");
+          return null;
+        }
+
+        return embedding;
+      } catch (err: unknown) {
+        logger.warn({ err }, "Failed to generate embedding");
+        return null;
+      }
+    },
+  };
+}

--- a/src/validation/search.ts
+++ b/src/validation/search.ts
@@ -1,0 +1,62 @@
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Query schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for validating search query parameters. */
+export const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .min(1, "Search query is required")
+    .max(500, "Search query must be at most 500 characters"),
+  category: z.string().optional(),
+  author: z.string().optional(),
+  dateFrom: z.iso.datetime().optional(),
+  dateTo: z.iso.datetime().optional(),
+  type: z.enum(["topics", "replies", "all"]).default("all"),
+  limit: z
+    .string()
+    .transform((val) => Number(val))
+    .pipe(z.number().int().min(1).max(100))
+    .optional()
+    .default(25),
+  cursor: z.string().optional(),
+});
+
+export type SearchQueryInput = z.infer<typeof searchQuerySchema>;
+
+// ---------------------------------------------------------------------------
+// Response schemas (for OpenAPI documentation)
+// ---------------------------------------------------------------------------
+
+/** Schema describing a single search result in API responses. */
+export const searchResultSchema = z.object({
+  type: z.enum(["topic", "reply"]),
+  uri: z.string(),
+  rkey: z.string(),
+  authorDid: z.string(),
+  title: z.string().nullable(),
+  content: z.string(),
+  category: z.string().nullable(),
+  communityDid: z.string(),
+  replyCount: z.number().nullable(),
+  reactionCount: z.number(),
+  createdAt: z.string(),
+  rank: z.number(),
+  // Reply-specific context
+  rootUri: z.string().nullable(),
+  rootTitle: z.string().nullable(),
+});
+
+export type SearchResult = z.infer<typeof searchResultSchema>;
+
+/** Schema for the search response. */
+export const searchResponseSchema = z.object({
+  results: z.array(searchResultSchema),
+  cursor: z.string().nullable(),
+  total: z.number(),
+  searchMode: z.enum(["fulltext", "hybrid"]),
+});
+
+export type SearchResponse = z.infer<typeof searchResponseSchema>;

--- a/tests/unit/db/schema/replies.test.ts
+++ b/tests/unit/db/schema/replies.test.ts
@@ -32,7 +32,8 @@ describe("replies schema", () => {
       "reactionCount",
       "createdAt",
       "indexedAt",
-      "embedding",
+      // Note: search_vector (tsvector) and embedding (vector) columns exist
+      // in the database but are managed outside Drizzle schema (migration 0010).
     ];
 
     for (const col of expected) {
@@ -56,7 +57,6 @@ describe("replies schema", () => {
   it("has nullable optional columns", () => {
     expect(columns.contentFormat.notNull).toBe(false);
     expect(columns.labels.notNull).toBe(false);
-    expect(columns.embedding.notNull).toBe(false);
   });
 
   it("has default value for reaction count", () => {

--- a/tests/unit/db/schema/topics.test.ts
+++ b/tests/unit/db/schema/topics.test.ts
@@ -33,7 +33,8 @@ describe("topics schema", () => {
       "lastActivityAt",
       "createdAt",
       "indexedAt",
-      "embedding",
+      // Note: search_vector (tsvector) and embedding (vector) columns exist
+      // in the database but are managed outside Drizzle schema (migration 0010).
     ];
 
     for (const col of expected) {
@@ -56,7 +57,6 @@ describe("topics schema", () => {
     expect(columns.contentFormat.notNull).toBe(false);
     expect(columns.tags.notNull).toBe(false);
     expect(columns.labels.notNull).toBe(false);
-    expect(columns.embedding.notNull).toBe(false);
   });
 
   it("has default values for counts", () => {

--- a/tests/unit/routes/search.test.ts
+++ b/tests/unit/routes/search.test.ts
@@ -1,0 +1,534 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+import type { RequestUser } from "../../../src/auth/middleware.js";
+
+// ---------------------------------------------------------------------------
+// Mock DB with execute method (search uses raw SQL, not Drizzle query builder)
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  execute: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Mock embedding service
+// ---------------------------------------------------------------------------
+
+const mockIsEnabled = vi.fn().mockReturnValue(false);
+const mockGenerateEmbedding = vi.fn().mockResolvedValue(null);
+
+vi.mock("../../../src/services/embedding.js", () => ({
+  createEmbeddingService: vi.fn(() => ({
+    isEnabled: mockIsEnabled,
+    generateEmbedding: mockGenerateEmbedding,
+  })),
+}));
+
+// Import routes AFTER mocking
+import { searchRoutes } from "../../../src/routes/search.js";
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_DID = "did:plc:testuser123";
+const TEST_COMMUNITY_DID = "did:plc:community123";
+const TEST_NOW = new Date("2026-02-13T12:00:00.000Z");
+
+// ---------------------------------------------------------------------------
+// Sample row builders (snake_case to match raw SQL output)
+// ---------------------------------------------------------------------------
+
+function sampleTopicRow(overrides?: Record<string, unknown>) {
+  return {
+    uri: `at://${TEST_DID}/forum.barazo.topic.post/topic123`,
+    rkey: "topic123",
+    author_did: TEST_DID,
+    title: "Test Topic Title",
+    content: "This is a test topic body content for search testing.",
+    category: "general",
+    community_did: TEST_COMMUNITY_DID,
+    reply_count: 5,
+    reaction_count: 3,
+    created_at: TEST_NOW,
+    rank: 0.75,
+    ...overrides,
+  };
+}
+
+function sampleReplyRow(overrides?: Record<string, unknown>) {
+  return {
+    uri: `at://${TEST_DID}/forum.barazo.topic.reply/reply123`,
+    rkey: "reply123",
+    author_did: TEST_DID,
+    content: "This is a reply to the test topic.",
+    community_did: TEST_COMMUNITY_DID,
+    reaction_count: 1,
+    created_at: TEST_NOW,
+    root_uri: `at://${TEST_DID}/forum.barazo.topic.post/topic123`,
+    root_title: "Test Topic Title",
+    rank: 0.6,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build app
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  app.decorateRequest("user", undefined as RequestUser | undefined);
+  app.decorate("db", mockDb as never);
+  app.decorate("env", {
+    EMBEDDING_URL: undefined,
+    AI_EMBEDDING_DIMENSIONS: 768,
+  } as never);
+  app.decorate("authMiddleware", {
+    requireAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+    optionalAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+  } as never);
+  app.decorate("cache", {} as never);
+
+  await app.register(searchRoutes());
+  await app.ready();
+
+  return app;
+}
+
+// ===========================================================================
+// Test suite
+// ===========================================================================
+
+describe("search routes", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockDb.execute.mockResolvedValue([]);
+    mockIsEnabled.mockReturnValue(false);
+    mockGenerateEmbedding.mockResolvedValue(null);
+
+    app = await buildTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // =========================================================================
+  // Validation
+  // =========================================================================
+
+  it("returns 400 when q is missing", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search",
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("returns 400 when q is empty", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=",
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  // =========================================================================
+  // Full-text search: basic results
+  // =========================================================================
+
+  it("returns empty results when no matches", async () => {
+    mockDb.execute.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=nonexistent",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: unknown[];
+      cursor: string | null;
+      total: number;
+      searchMode: string;
+    }>();
+    expect(body.results).toEqual([]);
+    expect(body.cursor).toBeNull();
+    expect(body.total).toBe(0);
+  });
+
+  it("returns topic results from full-text search", async () => {
+    const topicRow = sampleTopicRow();
+    // First execute: topic search
+    mockDb.execute.mockResolvedValueOnce([topicRow]);
+    // Second execute: reply search (empty)
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{
+        type: string;
+        uri: string;
+        authorDid: string;
+        title: string | null;
+        content: string;
+        category: string | null;
+        communityDid: string;
+        replyCount: number | null;
+        reactionCount: number;
+        rank: number;
+      }>;
+      searchMode: string;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.type).toBe("topic");
+    expect(body.results[0]?.uri).toBe(topicRow.uri);
+    expect(body.results[0]?.authorDid).toBe(TEST_DID);
+    expect(body.results[0]?.title).toBe("Test Topic Title");
+    expect(body.results[0]?.category).toBe("general");
+    expect(body.results[0]?.communityDid).toBe(TEST_COMMUNITY_DID);
+    expect(body.results[0]?.replyCount).toBe(5);
+    expect(body.results[0]?.reactionCount).toBe(3);
+  });
+
+  it("returns reply results with root topic context", async () => {
+    const replyRow = sampleReplyRow();
+    // First execute: topic search (empty)
+    mockDb.execute.mockResolvedValueOnce([]);
+    // Second execute: reply search
+    mockDb.execute.mockResolvedValueOnce([replyRow]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=reply",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{
+        type: string;
+        uri: string;
+        rootUri: string | null;
+        rootTitle: string | null;
+        title: string | null;
+        category: string | null;
+      }>;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.type).toBe("reply");
+    expect(body.results[0]?.rootUri).toBe(replyRow.root_uri);
+    expect(body.results[0]?.rootTitle).toBe("Test Topic Title");
+    // Replies have no own title or category
+    expect(body.results[0]?.title).toBeNull();
+    expect(body.results[0]?.category).toBeNull();
+  });
+
+  // =========================================================================
+  // Filters
+  // =========================================================================
+
+  it("applies category filter", async () => {
+    // Topic search returns results matching category
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ category: "support" }),
+    ]);
+    // Reply search (no category filter for replies)
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=help&category=support",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ category: string | null }>;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.category).toBe("support");
+
+    // db.execute should have been called (verifying it was invoked with the filter)
+    expect(mockDb.execute).toHaveBeenCalled();
+  });
+
+  it("applies author filter", async () => {
+    const authorDid = "did:plc:specific_author";
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ author_did: authorDid }),
+    ]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/search?q=post&author=${encodeURIComponent(authorDid)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ authorDid: string }>;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.authorDid).toBe(authorDid);
+  });
+
+  it("applies date range filters", async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test&dateFrom=2026-01-01T00:00:00Z&dateTo=2026-03-01T00:00:00Z",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1);
+    // The date filters are embedded in the SQL; we verify the query succeeded
+    expect(mockDb.execute).toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Type filter
+  // =========================================================================
+
+  it("handles type filter 'topics' (only topics searched)", async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test&type=topics",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ type: string }>;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.type).toBe("topic");
+
+    // Only one execute call -- topics only, no reply search
+    expect(mockDb.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles type filter 'replies' (only replies searched)", async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleReplyRow()]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test&type=replies",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ type: string }>;
+    }>();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.type).toBe("reply");
+
+    // Only one execute call -- replies only, no topic search
+    expect(mockDb.execute).toHaveBeenCalledTimes(1);
+  });
+
+  // =========================================================================
+  // Pagination
+  // =========================================================================
+
+  it("returns cursor for pagination when more results exist", async () => {
+    // Default limit is 25. Route fetches limit+1=26.
+    // Return 26 topic results to trigger hasMore.
+    const rows = Array.from({ length: 26 }, (_, i) =>
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/topic${String(i).padStart(3, "0")}`,
+        rkey: `topic${String(i).padStart(3, "0")}`,
+        rank: 1.0 - i * 0.01,
+      }),
+    );
+
+    // Topics search returns 26 rows
+    mockDb.execute.mockResolvedValueOnce(rows);
+    // Replies search returns empty
+    mockDb.execute.mockResolvedValueOnce([]);
+    // Count query for topics
+    mockDb.execute.mockResolvedValueOnce([{ count: "50" }]);
+    // Count query for replies
+    mockDb.execute.mockResolvedValueOnce([{ count: "10" }]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: unknown[];
+      cursor: string | null;
+      total: number;
+    }>();
+    // Should return exactly 25 (limit), not 26
+    expect(body.results).toHaveLength(25);
+    expect(body.cursor).toBeTruthy();
+    expect(body.total).toBe(60); // 50 topics + 10 replies
+  });
+
+  it("returns null cursor when fewer results than limit", async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      cursor: string | null;
+      total: number;
+    }>();
+    expect(body.cursor).toBeNull();
+    expect(body.total).toBe(1);
+  });
+
+  // =========================================================================
+  // Search mode reporting
+  // =========================================================================
+
+  it("reports searchMode as 'fulltext' when no embedding URL", async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ searchMode: string }>();
+    expect(body.searchMode).toBe("fulltext");
+  });
+
+  it("reports searchMode as 'hybrid' when embedding service is available and returns embeddings", async () => {
+    // Configure embedding service as enabled with working embeddings
+    mockIsEnabled.mockReturnValue(true);
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+    // Rebuild app to pick up updated mock state
+    const hybridApp = await buildTestApp();
+
+    // Full-text topic results
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()]);
+    // Full-text reply results
+    mockDb.execute.mockResolvedValueOnce([]);
+    // Vector topic results
+    mockDb.execute.mockResolvedValueOnce([]);
+    // Vector reply results
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await hybridApp.inject({
+      method: "GET",
+      url: "/api/search?q=semantic+query",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ searchMode: string }>();
+    expect(body.searchMode).toBe("hybrid");
+
+    await hybridApp.close();
+  });
+
+  it("falls back to fulltext when embedding service is enabled but returns null", async () => {
+    mockIsEnabled.mockReturnValue(true);
+    mockGenerateEmbedding.mockResolvedValue(null);
+
+    const fallbackApp = await buildTestApp();
+
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await fallbackApp.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{ searchMode: string }>();
+    expect(body.searchMode).toBe("fulltext");
+
+    await fallbackApp.close();
+  });
+
+  // =========================================================================
+  // Content snippeting
+  // =========================================================================
+
+  it("truncates long content to snippet", async () => {
+    const longContent = "A".repeat(500);
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ content: longContent }),
+    ]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ content: string }>;
+    }>();
+    // createSnippet truncates at 300 chars + "..."
+    expect(body.results[0]?.content.length).toBeLessThanOrEqual(303);
+    expect(body.results[0]?.content).toContain("...");
+  });
+
+  // =========================================================================
+  // Date serialization
+  // =========================================================================
+
+  it("serializes Date objects as ISO strings in results", async () => {
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ created_at: new Date("2026-02-13T12:00:00.000Z") }),
+    ]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ createdAt: string }>;
+    }>();
+    expect(body.results[0]?.createdAt).toBe("2026-02-13T12:00:00.000Z");
+  });
+
+  it("handles string dates from DB gracefully", async () => {
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ created_at: "2026-02-13T12:00:00.000Z" }),
+    ]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/search?q=test",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<{
+      results: Array<{ createdAt: string }>;
+    }>();
+    expect(body.results[0]?.createdAt).toBe("2026-02-13T12:00:00.000Z");
+  });
+});

--- a/tests/unit/services/embedding.test.ts
+++ b/tests/unit/services/embedding.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createEmbeddingService } from "../../../src/services/embedding.js";
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+  level: "info",
+  silent: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("embedding service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Disabled mode (no URL)
+  // =========================================================================
+
+  describe("when disabled (no URL)", () => {
+    it("isEnabled returns false when URL is undefined", () => {
+      const service = createEmbeddingService(
+        undefined,
+        768,
+        mockLogger as never,
+      );
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it("isEnabled returns false when URL is empty string", () => {
+      const service = createEmbeddingService("", 768, mockLogger as never);
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it("generateEmbedding returns null when disabled", async () => {
+      const service = createEmbeddingService(
+        undefined,
+        768,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+      expect(result).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Enabled mode
+  // =========================================================================
+
+  describe("when enabled", () => {
+    const TEST_URL = "http://localhost:11434/api/embeddings";
+    const TEST_DIMENSIONS = 768;
+    const mockFetch = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal("fetch", mockFetch);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("isEnabled returns true when URL is provided", () => {
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      expect(service.isEnabled()).toBe(true);
+    });
+
+    it("generateEmbedding returns embedding array on success", async () => {
+      const expectedEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: expectedEmbedding }],
+        }),
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toEqual(expectedEmbedding);
+    });
+
+    it("calls the correct URL with correct payload", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+        }),
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      await service.generateEmbedding("hello world");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch.mock.calls[0]?.[0]).toBe(TEST_URL);
+
+      const fetchOptions = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      expect(fetchOptions.method).toBe("POST");
+      expect(fetchOptions.headers).toEqual({
+        "Content-Type": "application/json",
+      });
+
+      const body = JSON.parse(fetchOptions.body as string) as {
+        input: string;
+        model: string;
+        dimensions: number;
+      };
+      expect(body.input).toBe("hello world");
+      expect(body.model).toBe("default");
+      expect(body.dimensions).toBe(TEST_DIMENSIONS);
+    });
+
+    it("returns null on API error (non-OK status)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { status: 500, url: TEST_URL },
+        "Embedding API returned non-OK status",
+      );
+    });
+
+    it("returns null on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("fetch failed"));
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { err: expect.any(Error) as Error },
+        "Failed to generate embedding",
+      );
+    });
+
+    it("returns null on invalid response format (missing data)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Embedding API returned empty or invalid embedding",
+      );
+    });
+
+    it("returns null on invalid response format (empty embedding)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: [] }],
+        }),
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Embedding API returned empty or invalid embedding",
+      );
+    });
+
+    it("returns null on invalid response format (non-array embedding)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: "not-an-array" }],
+        }),
+      });
+
+      const service = createEmbeddingService(
+        TEST_URL,
+        TEST_DIMENSIONS,
+        mockLogger as never,
+      );
+      const result = await service.generateEmbedding("test query");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/validation/search.test.ts
+++ b/tests/unit/validation/search.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import { searchQuerySchema } from "../../../src/validation/search.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("search validation schemas", () => {
+  // =========================================================================
+  // searchQuerySchema
+  // =========================================================================
+
+  describe("searchQuerySchema", () => {
+    it("parses a valid query with all fields", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test query",
+        category: "general",
+        author: "did:plc:user123",
+        dateFrom: "2026-01-01T00:00:00Z",
+        dateTo: "2026-02-01T00:00:00Z",
+        type: "topics",
+        limit: "10",
+        cursor: "abc123base64",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.q).toBe("test query");
+        expect(result.data.category).toBe("general");
+        expect(result.data.author).toBe("did:plc:user123");
+        expect(result.data.dateFrom).toBe("2026-01-01T00:00:00Z");
+        expect(result.data.dateTo).toBe("2026-02-01T00:00:00Z");
+        expect(result.data.type).toBe("topics");
+        expect(result.data.limit).toBe(10);
+        expect(result.data.cursor).toBe("abc123base64");
+      }
+    });
+
+    it("parses a minimal valid query (only q)", () => {
+      const result = searchQuerySchema.safeParse({ q: "hello" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.q).toBe("hello");
+      }
+    });
+
+    it("fails when q is missing", () => {
+      const result = searchQuerySchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when q is empty string", () => {
+      const result = searchQuerySchema.safeParse({ q: "" });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when q exceeds 500 characters", () => {
+      const result = searchQuerySchema.safeParse({ q: "a".repeat(501) });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts q at exactly 500 characters", () => {
+      const result = searchQuerySchema.safeParse({ q: "a".repeat(500) });
+      expect(result.success).toBe(true);
+    });
+
+    it("defaults type to 'all' when not provided", () => {
+      const result = searchQuerySchema.safeParse({ q: "test" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe("all");
+      }
+    });
+
+    it("defaults limit to 25 when not provided", () => {
+      const result = searchQuerySchema.safeParse({ q: "test" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(25);
+      }
+    });
+
+    it("accepts type 'topics'", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        type: "topics",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe("topics");
+      }
+    });
+
+    it("accepts type 'replies'", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        type: "replies",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe("replies");
+      }
+    });
+
+    it("accepts type 'all'", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", type: "all" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe("all");
+      }
+    });
+
+    it("fails for invalid type value", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        type: "invalid",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when limit is below minimum (0)", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "0" });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when limit exceeds maximum (101)", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "101" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts limit at boundary 1", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "1" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(1);
+      }
+    });
+
+    it("accepts limit at boundary 100", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "100" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(100);
+      }
+    });
+
+    it("transforms string limit to number", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "42" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(42);
+        expect(typeof result.data.limit).toBe("number");
+      }
+    });
+
+    it("fails for non-numeric limit", () => {
+      const result = searchQuerySchema.safeParse({ q: "test", limit: "abc" });
+      expect(result.success).toBe(false);
+    });
+
+    it("parses optional category filter", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        category: "support",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.category).toBe("support");
+      }
+    });
+
+    it("parses optional author filter", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        author: "did:plc:abc123",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.author).toBe("did:plc:abc123");
+      }
+    });
+
+    it("validates dateFrom as ISO datetime", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        dateFrom: "2026-01-15T10:30:00Z",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.dateFrom).toBe("2026-01-15T10:30:00Z");
+      }
+    });
+
+    it("validates dateTo as ISO datetime", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        dateTo: "2026-02-15T23:59:59Z",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.dateTo).toBe("2026-02-15T23:59:59Z");
+      }
+    });
+
+    it("fails for invalid dateFrom format", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        dateFrom: "not-a-date",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for invalid dateTo format", () => {
+      const result = searchQuerySchema.safeParse({
+        q: "test",
+        dateTo: "2026/01/15",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("parses optional cursor", () => {
+      const cursor = Buffer.from(
+        JSON.stringify({ rank: 0.5, uri: "at://did:plc:test/forum.barazo.topic.post/abc" }),
+      ).toString("base64");
+      const result = searchQuerySchema.safeParse({ q: "test", cursor });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.cursor).toBe(cursor);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `GET /api/search` endpoint with PostgreSQL full-text search (tsvector + GIN indexes)
- Add optional semantic search via pgvector when `EMBEDDING_URL` env var is configured
- Reciprocal Rank Fusion (RRF) merges full-text and vector results in hybrid mode
- Embedding service with OpenAI-compatible API (works with Ollama, OpenRouter, etc.)
- Database triggers auto-maintain `search_vector` tsvector columns on topics and replies
- Filters: category, author, date range, content type (topics/replies/all)
- Cursor-based pagination with relevance ranking
- Graceful degradation: full-text search always works, semantic activates only when configured
- Migration 0010: pgvector extension, tsvector columns, GIN/HNSW indexes, trigger functions
- 54 new tests (664 total), all passing

## Test plan

- [x] Full-text search returns ranked results
- [x] Filters (category, author, date range) applied correctly
- [x] Cursor-based pagination works
- [x] Embedding service gracefully degrades when disabled
- [x] Embedding service handles API errors without throwing
- [x] Hybrid search mode detected when embedding available
- [x] Search validation rejects invalid parameters
- [x] Content snippets truncated to 300 chars
- [x] Mod-deleted topics excluded from results
- [x] All 664 tests pass, lint clean, typecheck clean