### PR TITLE
feat(api): add notification endpoints (M9)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "./src/db/schema/categories.ts",
     "./src/db/schema/moderation-actions.ts",
     "./src/db/schema/reports.ts",
+    "./src/db/schema/notifications.ts",
   ],
   out: "./drizzle",
   dialect: "postgresql",

--- a/drizzle/0011_fresh_veda.sql
+++ b/drizzle/0011_fresh_veda.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "notifications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"recipient_did" text NOT NULL,
+	"type" text NOT NULL,
+	"subject_uri" text NOT NULL,
+	"actor_did" text NOT NULL,
+	"community_did" text NOT NULL,
+	"read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "notifications_recipient_did_idx" ON "notifications" USING btree ("recipient_did");--> statement-breakpoint
+CREATE INDEX "notifications_recipient_read_idx" ON "notifications" USING btree ("recipient_did","read");--> statement-breakpoint
+CREATE INDEX "notifications_created_at_idx" ON "notifications" USING btree ("created_at");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1388 @@
+{
+  "id": "577fe24e-9352-49cb-af6e-444ad3f0a3d7",
+  "prevId": "38f94dc1-1f3f-4ecc-8d82-4e4520cff5cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_score": {
+          "name": "reputation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "age_declared_at": {
+          "name": "age_declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturity_pref": {
+          "name": "maturity_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firehose_cursor": {
+      "name": "firehose_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_mod_deleted": {
+          "name": "is_mod_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "topics_author_did_idx": {
+          "name": "topics_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_category_idx": {
+          "name": "topics_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_created_at_idx": {
+          "name": "topics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_last_activity_at_idx": {
+          "name": "topics_last_activity_at_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_community_did_idx": {
+          "name": "topics_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replies": {
+      "name": "replies",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cid": {
+          "name": "root_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_uri": {
+          "name": "parent_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_cid": {
+          "name": "parent_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replies_author_did_idx": {
+          "name": "replies_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_root_uri_idx": {
+          "name": "replies_root_uri_idx",
+          "columns": [
+            {
+              "expression": "root_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_parent_uri_idx": {
+          "name": "replies_parent_uri_idx",
+          "columns": [
+            {
+              "expression": "parent_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_created_at_idx": {
+          "name": "replies_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_community_did_idx": {
+          "name": "replies_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_cid": {
+          "name": "subject_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_author_did_idx": {
+          "name": "reactions_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_subject_uri_idx": {
+          "name": "reactions_subject_uri_idx",
+          "columns": [
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_community_did_idx": {
+          "name": "reactions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_author_subject_type_uniq": {
+          "name": "reactions_author_subject_type_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_did",
+            "subject_uri",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tracked_at": {
+          "name": "tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "initialized": {
+          "name": "initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_did": {
+          "name": "admin_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_name": {
+          "name": "community_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Barazo Community'"
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "reaction_set": {
+          "name": "reaction_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"like\"]'::jsonb"
+        },
+        "moderation_thresholds": {
+          "name": "moderation_thresholds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"autoBlockReportCount\":5,\"warnThreshold\":3}'::jsonb"
+        },
+        "word_filter": {
+          "name": "word_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_community_did_idx": {
+          "name": "categories_slug_community_did_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_parent_id_idx": {
+          "name": "categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_community_did_idx": {
+          "name": "categories_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_maturity_rating_idx": {
+          "name": "categories_maturity_rating_idx",
+          "columns": [
+            {
+              "expression": "maturity_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_fk": {
+          "name": "categories_parent_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_did": {
+          "name": "moderator_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_actions_moderator_did_idx": {
+          "name": "mod_actions_moderator_did_idx",
+          "columns": [
+            {
+              "expression": "moderator_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_community_did_idx": {
+          "name": "mod_actions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_created_at_idx": {
+          "name": "mod_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_uri_idx": {
+          "name": "mod_actions_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_did_idx": {
+          "name": "mod_actions_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_did": {
+          "name": "reporter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_type": {
+          "name": "reason_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution_type": {
+          "name": "resolution_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_reporter_did_idx": {
+          "name": "reports_reporter_did_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_uri_idx": {
+          "name": "reports_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_did_idx": {
+          "name": "reports_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_community_did_idx": {
+          "name": "reports_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_unique_reporter_target_idx": {
+          "name": "reports_unique_reporter_target_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_did": {
+          "name": "recipient_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_did": {
+          "name": "actor_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_did_idx": {
+          "name": "notifications_recipient_did_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1771036752885,
       "tag": "0010_dear_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1771037848181,
+      "tag": "0011_fresh_veda",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import { adminSettingsRoutes } from "./routes/admin-settings.js";
 import { reactionRoutes } from "./routes/reactions.js";
 import { moderationRoutes } from "./routes/moderation.js";
 import { searchRoutes } from "./routes/search.js";
+import { notificationRoutes } from "./routes/notifications.js";
 import { createRequireAdmin } from "./auth/require-admin.js";
 import { createSetupService } from "./setup/service.js";
 import type { SetupService } from "./setup/service.js";
@@ -193,6 +194,7 @@ export async function buildApp(env: Env) {
   await app.register(reactionRoutes());
   await app.register(moderationRoutes());
   await app.register(searchRoutes());
+  await app.register(notificationRoutes());
 
   // OpenAPI spec endpoint (after routes so all schemas are registered)
   app.get("/api/openapi.json", { schema: { hide: true } }, async (_request, reply) => {

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -8,3 +8,4 @@ export { communitySettings } from "./community-settings.js";
 export { categories } from "./categories.js";
 export { moderationActions } from "./moderation-actions.js";
 export { reports } from "./reports.js";
+export { notifications } from "./notifications.js";

--- a/src/db/schema/notifications.ts
+++ b/src/db/schema/notifications.ts
@@ -1,0 +1,34 @@
+import {
+  pgTable,
+  text,
+  boolean,
+  timestamp,
+  index,
+  serial,
+} from "drizzle-orm/pg-core";
+
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: serial("id").primaryKey(),
+    recipientDid: text("recipient_did").notNull(),
+    type: text("type", {
+      enum: ["reply", "reaction", "mention", "mod_action"],
+    }).notNull(),
+    subjectUri: text("subject_uri").notNull(),
+    actorDid: text("actor_did").notNull(),
+    communityDid: text("community_did").notNull(),
+    read: boolean("read").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("notifications_recipient_did_idx").on(table.recipientDid),
+    index("notifications_recipient_read_idx").on(
+      table.recipientDid,
+      table.read,
+    ),
+    index("notifications_created_at_idx").on(table.createdAt),
+  ],
+);

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,0 +1,343 @@
+import { eq, and, sql, desc } from "drizzle-orm";
+import type { FastifyPluginCallback } from "fastify";
+import { badRequest } from "../lib/api-errors.js";
+import {
+  notificationQuerySchema,
+  markReadSchema,
+} from "../validation/notifications.js";
+import { notifications } from "../db/schema/notifications.js";
+
+// ---------------------------------------------------------------------------
+// OpenAPI JSON Schema definitions
+// ---------------------------------------------------------------------------
+
+const notificationJsonSchema = {
+  type: "object" as const,
+  properties: {
+    id: { type: "number" as const },
+    type: { type: "string" as const },
+    subjectUri: { type: "string" as const },
+    actorDid: { type: "string" as const },
+    communityDid: { type: "string" as const },
+    read: { type: "boolean" as const },
+    createdAt: { type: "string" as const, format: "date-time" as const },
+  },
+};
+
+const errorJsonSchema = {
+  type: "object" as const,
+  properties: {
+    error: { type: "string" as const },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a notification row from the DB into a JSON-safe response object.
+ * Converts Date fields to ISO strings.
+ */
+function serializeNotification(row: typeof notifications.$inferSelect) {
+  return {
+    id: row.id,
+    type: row.type,
+    subjectUri: row.subjectUri,
+    actorDid: row.actorDid,
+    communityDid: row.communityDid,
+    read: row.read,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Encode a pagination cursor from createdAt + id.
+ */
+function encodeCursor(createdAt: string, id: number): string {
+  return Buffer.from(JSON.stringify({ createdAt, id })).toString("base64");
+}
+
+/**
+ * Decode a pagination cursor. Returns null if invalid.
+ */
+function decodeCursor(
+  cursor: string,
+): { createdAt: string; id: number } | null {
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(cursor, "base64").toString("utf-8"),
+    ) as Record<string, unknown>;
+    if (
+      typeof decoded.createdAt === "string" &&
+      typeof decoded.id === "number"
+    ) {
+      return { createdAt: decoded.createdAt, id: decoded.id };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notification routes plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * Notification routes for the Barazo forum.
+ *
+ * - GET  /api/notifications       -- List notifications (auth required)
+ * - PUT  /api/notifications/read  -- Mark notification(s) as read (auth required)
+ * - GET  /api/notifications/count -- Unread notification count (auth required)
+ */
+export function notificationRoutes(): FastifyPluginCallback {
+  return (app, _opts, done) => {
+    const { db, authMiddleware } = app;
+
+    // -------------------------------------------------------------------
+    // GET /api/notifications (auth required)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/notifications",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Notifications"],
+          summary: "List notifications for the authenticated user",
+          security: [{ bearerAuth: [] }],
+          querystring: {
+            type: "object",
+            properties: {
+              limit: { type: "string" },
+              cursor: { type: "string" },
+              unreadOnly: { type: "string" },
+            },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                notifications: {
+                  type: "array",
+                  items: notificationJsonSchema,
+                },
+                cursor: { type: ["string", "null"] },
+                total: { type: "number" },
+              },
+            },
+            400: errorJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const user = request.user;
+        if (!user) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const parsed = notificationQuerySchema.safeParse(request.query);
+        if (!parsed.success) {
+          throw badRequest("Invalid query parameters");
+        }
+
+        const { limit, cursor, unreadOnly } = parsed.data;
+
+        // Build conditions
+        const conditions = [eq(notifications.recipientDid, user.did)];
+
+        if (unreadOnly) {
+          conditions.push(eq(notifications.read, false));
+        }
+
+        // Cursor-based pagination
+        if (cursor) {
+          const decoded = decodeCursor(cursor);
+          if (decoded) {
+            conditions.push(
+              sql`(${notifications.read}, ${notifications.createdAt}, ${notifications.id}) > (${decoded.createdAt === "unread" ? false : true}, ${decoded.createdAt === "unread" ? decoded.createdAt : decoded.createdAt}::timestamptz, ${decoded.id})`,
+            );
+          }
+        }
+
+        const whereClause = and(...conditions);
+
+        // Fetch limit + 1 to detect if there are more pages
+        const fetchLimit = limit + 1;
+
+        // Order: unread first (read=false < read=true), then newest first
+        const rows = await db
+          .select()
+          .from(notifications)
+          .where(whereClause)
+          .orderBy(
+            sql`${notifications.read} ASC`,
+            desc(notifications.createdAt),
+          )
+          .limit(fetchLimit);
+
+        const hasMore = rows.length > limit;
+        const resultRows = hasMore ? rows.slice(0, limit) : rows;
+        const serialized = resultRows.map(serializeNotification);
+
+        // Get total count for the user
+        const countResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(notifications)
+          .where(eq(notifications.recipientDid, user.did));
+
+        const total = countResult[0]?.count ?? 0;
+
+        let nextCursor: string | null = null;
+        if (hasMore) {
+          const lastRow = resultRows[resultRows.length - 1];
+          if (lastRow) {
+            nextCursor = encodeCursor(
+              lastRow.createdAt.toISOString(),
+              lastRow.id,
+            );
+          }
+        }
+
+        return reply.status(200).send({
+          notifications: serialized,
+          cursor: nextCursor,
+          total,
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // PUT /api/notifications/read (auth required)
+    // -------------------------------------------------------------------
+
+    app.put(
+      "/api/notifications/read",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Notifications"],
+          summary: "Mark notification(s) as read",
+          security: [{ bearerAuth: [] }],
+          body: {
+            type: "object",
+            properties: {
+              notificationId: { type: "number" },
+              all: { type: "boolean" },
+            },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                success: { type: "boolean" },
+              },
+            },
+            400: errorJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const user = request.user;
+        if (!user) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const parsed = markReadSchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest("Invalid request body");
+        }
+
+        const { notificationId, all } = parsed.data;
+
+        if (!notificationId && !all) {
+          throw badRequest(
+            "Either notificationId or all must be provided",
+          );
+        }
+
+        if (all) {
+          // Mark all unread notifications as read for this user
+          await db
+            .update(notifications)
+            .set({ read: true })
+            .where(
+              and(
+                eq(notifications.recipientDid, user.did),
+                eq(notifications.read, false),
+              ),
+            );
+        } else if (notificationId) {
+          // Mark a single notification as read (scoped to user)
+          await db
+            .update(notifications)
+            .set({ read: true })
+            .where(
+              and(
+                eq(notifications.id, notificationId),
+                eq(notifications.recipientDid, user.did),
+              ),
+            );
+        }
+
+        return reply.status(200).send({ success: true });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // GET /api/notifications/count (auth required)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/notifications/count",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Notifications"],
+          summary: "Get unread notification count",
+          security: [{ bearerAuth: [] }],
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                unread: { type: "number" },
+              },
+            },
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const user = request.user;
+        if (!user) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const countResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(notifications)
+          .where(
+            and(
+              eq(notifications.recipientDid, user.did),
+              eq(notifications.read, false),
+            ),
+          );
+
+        const unread = countResult[0]?.count ?? 0;
+
+        return reply.status(200).send({ unread });
+      },
+    );
+
+    done();
+  };
+}

--- a/src/validation/notifications.ts
+++ b/src/validation/notifications.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Query schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for listing notifications with pagination. */
+export const notificationQuerySchema = z.object({
+  limit: z
+    .string()
+    .transform((val) => Number(val))
+    .pipe(z.number().int().min(1).max(100))
+    .optional()
+    .default(25),
+  cursor: z.string().optional(),
+  unreadOnly: z
+    .string()
+    .transform((val) => val === "true")
+    .optional(),
+});
+
+export type NotificationQueryInput = z.infer<typeof notificationQuerySchema>;
+
+// ---------------------------------------------------------------------------
+// Body schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for marking notifications as read. */
+export const markReadSchema = z.object({
+  notificationId: z.number().int().positive().optional(),
+  all: z.boolean().optional(),
+});
+
+export type MarkReadInput = z.infer<typeof markReadSchema>;

--- a/tests/unit/db/schema/notifications.test.ts
+++ b/tests/unit/db/schema/notifications.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { notifications } from "../../../../src/db/schema/notifications.js";
+import { getTableName, getTableColumns } from "drizzle-orm";
+
+describe("notifications schema", () => {
+  it("should have the correct table name", () => {
+    expect(getTableName(notifications)).toBe("notifications");
+  });
+
+  it("should have all required columns", () => {
+    const columns = getTableColumns(notifications);
+    const columnNames = Object.keys(columns);
+
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("recipientDid");
+    expect(columnNames).toContain("type");
+    expect(columnNames).toContain("subjectUri");
+    expect(columnNames).toContain("actorDid");
+    expect(columnNames).toContain("communityDid");
+    expect(columnNames).toContain("read");
+    expect(columnNames).toContain("createdAt");
+  });
+
+  it("should have id as primary key", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.id.primary).toBe(true);
+  });
+
+  it("should mark required columns as not null", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.recipientDid.notNull).toBe(true);
+    expect(columns.type.notNull).toBe(true);
+    expect(columns.subjectUri.notNull).toBe(true);
+    expect(columns.actorDid.notNull).toBe(true);
+    expect(columns.communityDid.notNull).toBe(true);
+    expect(columns.read.notNull).toBe(true);
+    expect(columns.createdAt.notNull).toBe(true);
+  });
+
+  it("should have exactly 8 columns", () => {
+    const columns = getTableColumns(notifications);
+    expect(Object.keys(columns)).toHaveLength(8);
+  });
+
+  it("should have a default value for read (false)", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.read.hasDefault).toBe(true);
+  });
+
+  it("should have a default value for createdAt", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.createdAt.hasDefault).toBe(true);
+  });
+});

--- a/tests/unit/routes/notifications.test.ts
+++ b/tests/unit/routes/notifications.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+import type { Env } from "../../../src/config/env.js";
+import type { AuthMiddleware, RequestUser } from "../../../src/auth/middleware.js";
+import type { SessionService } from "../../../src/auth/session.js";
+import type { SetupService } from "../../../src/setup/service.js";
+import { type DbChain, createChainableProxy, createMockDb } from "../../helpers/mock-db.js";
+
+// Import routes
+import { notificationRoutes } from "../../../src/routes/notifications.js";
+
+// ---------------------------------------------------------------------------
+// Mock env
+// ---------------------------------------------------------------------------
+
+const mockEnv = {
+  COMMUNITY_DID: "did:plc:community123",
+  RATE_LIMIT_WRITE: 10,
+  RATE_LIMIT_READ_ANON: 100,
+  RATE_LIMIT_READ_AUTH: 300,
+} as Env;
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_DID = "did:plc:testuser123";
+const TEST_HANDLE = "alice.bsky.social";
+const TEST_SID = "a".repeat(64);
+const ACTOR_DID = "did:plc:actor456";
+const COMMUNITY_DID = "did:plc:community123";
+const TEST_SUBJECT_URI = `at://${ACTOR_DID}/forum.barazo.topic.post/topic123`;
+const TEST_NOW = "2026-02-14T12:00:00.000Z";
+
+// ---------------------------------------------------------------------------
+// Mock user builders
+// ---------------------------------------------------------------------------
+
+function testUser(overrides?: Partial<RequestUser>): RequestUser {
+  return {
+    did: TEST_DID,
+    handle: TEST_HANDLE,
+    sid: TEST_SID,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chainable mock DB
+// ---------------------------------------------------------------------------
+
+const mockDb = createMockDb();
+
+let selectChain: DbChain;
+let updateChain: DbChain;
+
+function resetAllDbMocks(): void {
+  selectChain = createChainableProxy([]);
+  updateChain = createChainableProxy([]);
+  mockDb.insert.mockReturnValue(createChainableProxy());
+  mockDb.select.mockReturnValue(selectChain);
+  mockDb.update.mockReturnValue(updateChain);
+  mockDb.delete.mockReturnValue(createChainableProxy());
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Intentionally async mock for Drizzle transaction
+  mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+    return await fn(mockDb);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware mocks
+// ---------------------------------------------------------------------------
+
+function createMockAuthMiddleware(user?: RequestUser): AuthMiddleware {
+  return {
+    requireAuth: async (request, reply) => {
+      if (!user) {
+        await reply.status(401).send({ error: "Authentication required" });
+        return;
+      }
+      request.user = user;
+    },
+    optionalAuth: (request, _reply) => {
+      if (user) {
+        request.user = user;
+      }
+      return Promise.resolve();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sample data builders
+// ---------------------------------------------------------------------------
+
+function sampleNotificationRow(overrides?: Record<string, unknown>) {
+  return {
+    id: 1,
+    recipientDid: TEST_DID,
+    type: "reply",
+    subjectUri: TEST_SUBJECT_URI,
+    actorDid: ACTOR_DID,
+    communityDid: COMMUNITY_DID,
+    read: false,
+    createdAt: new Date(TEST_NOW),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build app with mocked deps
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  app.decorate("db", mockDb as never);
+  app.decorate("env", mockEnv);
+  app.decorate("authMiddleware", createMockAuthMiddleware(user));
+  app.decorate("firehose", {} as never);
+  app.decorate("oauthClient", {} as never);
+  app.decorate("sessionService", {} as SessionService);
+  app.decorate("setupService", {} as SetupService);
+  app.decorate("cache", {} as never);
+  app.decorateRequest("user", undefined as RequestUser | undefined);
+
+  await app.register(notificationRoutes());
+  await app.ready();
+
+  return app;
+}
+
+// ===========================================================================
+// Test suite
+// ===========================================================================
+
+describe("notification routes", () => {
+  // =========================================================================
+  // GET /api/notifications
+  // =========================================================================
+
+  describe("GET /api/notifications", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "GET",
+        url: "/api/notifications",
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+
+    it("returns empty list for user with no notifications", async () => {
+      // The route does two select queries:
+      // 1. select().from().where().orderBy().limit() -- notification list
+      // 2. select({ count }).from().where() -- total count
+      // Both use the same selectChain. The first where() must return the
+      // chainable thenable so that .orderBy().limit() works. The second
+      // where() can resolve directly to the count result.
+      //
+      // Use mockImplementationOnce for the first where() to preserve
+      // chaining, then mockResolvedValueOnce for the second.
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      };
+      selectChain.where.mockReturnValueOnce(chainableThenable);
+      selectChain.limit.mockResolvedValueOnce([]);
+      // Second select().from().where() for count
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        notifications: unknown[];
+        cursor: string | null;
+        total: number;
+      }>();
+      expect(body.notifications).toEqual([]);
+      expect(body.cursor).toBeNull();
+      expect(body.total).toBe(0);
+    });
+
+    it("returns notifications ordered by unread first", async () => {
+      const unreadNotification = sampleNotificationRow({
+        id: 2,
+        read: false,
+        createdAt: new Date("2026-02-14T11:00:00.000Z"),
+      });
+      const readNotification = sampleNotificationRow({
+        id: 1,
+        read: true,
+        createdAt: new Date("2026-02-14T10:00:00.000Z"),
+      });
+
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      };
+      selectChain.where.mockReturnValueOnce(chainableThenable);
+      selectChain.limit.mockResolvedValueOnce([unreadNotification, readNotification]);
+      selectChain.where.mockResolvedValueOnce([{ count: 2 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        notifications: Array<{ id: number; read: boolean }>;
+        total: number;
+      }>();
+      expect(body.notifications).toHaveLength(2);
+      expect(body.notifications[0]?.read).toBe(false);
+      expect(body.notifications[1]?.read).toBe(true);
+      expect(body.total).toBe(2);
+    });
+
+    it("supports pagination with cursor", async () => {
+      // Return limit + 1 to signal more pages exist
+      const rows = Array.from({ length: 26 }, (_, i) =>
+        sampleNotificationRow({
+          id: i + 1,
+          createdAt: new Date(`2026-02-14T${String(12 - Math.floor(i / 2)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00.000Z`),
+        }),
+      );
+
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      };
+      selectChain.where.mockReturnValueOnce(chainableThenable);
+      selectChain.limit.mockResolvedValueOnce(rows);
+      selectChain.where.mockResolvedValueOnce([{ count: 50 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        notifications: unknown[];
+        cursor: string | null;
+        total: number;
+      }>();
+      expect(body.notifications).toHaveLength(25);
+      expect(body.cursor).toBeTruthy();
+      expect(body.total).toBe(50);
+    });
+
+    it("returns null cursor when fewer items than limit", async () => {
+      const rows = [sampleNotificationRow()];
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      };
+      selectChain.where.mockReturnValueOnce(chainableThenable);
+      selectChain.limit.mockResolvedValueOnce(rows);
+      selectChain.where.mockResolvedValueOnce([{ count: 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications?limit=25",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        notifications: unknown[];
+        cursor: string | null;
+      }>();
+      expect(body.notifications).toHaveLength(1);
+      expect(body.cursor).toBeNull();
+    });
+
+    it("serializes notification dates as ISO strings", async () => {
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      };
+      selectChain.where.mockReturnValueOnce(chainableThenable);
+      selectChain.limit.mockResolvedValueOnce([sampleNotificationRow()]);
+      selectChain.where.mockResolvedValueOnce([{ count: 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        notifications: Array<{
+          createdAt: string;
+          type: string;
+          actorDid: string;
+        }>;
+      }>();
+      expect(body.notifications[0]?.createdAt).toBe(TEST_NOW);
+      expect(body.notifications[0]?.type).toBe("reply");
+      expect(body.notifications[0]?.actorDid).toBe(ACTOR_DID);
+    });
+
+    it("returns 400 for invalid limit", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications?limit=abc",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 for limit exceeding max (101)", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications?limit=101",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 for limit below min (0)", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications?limit=0",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // PUT /api/notifications/read
+  // =========================================================================
+
+  describe("PUT /api/notifications/read", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("marks single notification as read", async () => {
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/notifications/read",
+        headers: { authorization: "Bearer test-token" },
+        payload: { notificationId: 42 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{ success: boolean }>();
+      expect(body.success).toBe(true);
+      expect(mockDb.update).toHaveBeenCalledOnce();
+    });
+
+    it("marks all notifications as read", async () => {
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/notifications/read",
+        headers: { authorization: "Bearer test-token" },
+        payload: { all: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{ success: boolean }>();
+      expect(body.success).toBe(true);
+      expect(mockDb.update).toHaveBeenCalledOnce();
+    });
+
+    it("returns 400 when neither notificationId nor all provided", async () => {
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/notifications/read",
+        headers: { authorization: "Bearer test-token" },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "PUT",
+        url: "/api/notifications/read",
+        payload: { all: true },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+  });
+
+  // =========================================================================
+  // GET /api/notifications/count
+  // =========================================================================
+
+  describe("GET /api/notifications/count", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns unread count", async () => {
+      selectChain.where.mockResolvedValueOnce([{ count: 5 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications/count",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{ unread: number }>();
+      expect(body.unread).toBe(5);
+    });
+
+    it("returns zero when no unread notifications", async () => {
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/notifications/count",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{ unread: number }>();
+      expect(body.unread).toBe(0);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "GET",
+        url: "/api/notifications/count",
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+  });
+});

--- a/tests/unit/validation/notifications.test.ts
+++ b/tests/unit/validation/notifications.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  notificationQuerySchema,
+  markReadSchema,
+} from "../../../src/validation/notifications.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("notification validation schemas", () => {
+  // =========================================================================
+  // notificationQuerySchema
+  // =========================================================================
+
+  describe("notificationQuerySchema", () => {
+    it("parses a valid query with all fields", () => {
+      const result = notificationQuerySchema.safeParse({
+        limit: "10",
+        cursor: "abc123base64",
+        unreadOnly: "true",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(10);
+        expect(result.data.cursor).toBe("abc123base64");
+        expect(result.data.unreadOnly).toBe(true);
+      }
+    });
+
+    it("parses a minimal valid query (no fields)", () => {
+      const result = notificationQuerySchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(25);
+        expect(result.data.cursor).toBeUndefined();
+        expect(result.data.unreadOnly).toBeUndefined();
+      }
+    });
+
+    it("defaults limit to 25 when not provided", () => {
+      const result = notificationQuerySchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(25);
+      }
+    });
+
+    it("transforms string limit to number", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "42" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(42);
+        expect(typeof result.data.limit).toBe("number");
+      }
+    });
+
+    it("accepts limit at boundary 1", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "1" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(1);
+      }
+    });
+
+    it("accepts limit at boundary 100", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "100" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.limit).toBe(100);
+      }
+    });
+
+    it("fails when limit is below minimum (0)", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "0" });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when limit exceeds maximum (101)", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "101" });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for non-numeric limit", () => {
+      const result = notificationQuerySchema.safeParse({ limit: "abc" });
+      expect(result.success).toBe(false);
+    });
+
+    it("transforms unreadOnly 'true' to boolean true", () => {
+      const result = notificationQuerySchema.safeParse({
+        unreadOnly: "true",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.unreadOnly).toBe(true);
+      }
+    });
+
+    it("transforms unreadOnly 'false' to boolean false", () => {
+      const result = notificationQuerySchema.safeParse({
+        unreadOnly: "false",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.unreadOnly).toBe(false);
+      }
+    });
+
+    it("parses optional cursor", () => {
+      const cursor = Buffer.from(
+        JSON.stringify({ createdAt: "2026-02-14T12:00:00Z", id: 42 }),
+      ).toString("base64");
+      const result = notificationQuerySchema.safeParse({ cursor });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.cursor).toBe(cursor);
+      }
+    });
+  });
+
+  // =========================================================================
+  // markReadSchema
+  // =========================================================================
+
+  describe("markReadSchema", () => {
+    it("parses with notificationId", () => {
+      const result = markReadSchema.safeParse({ notificationId: 42 });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.notificationId).toBe(42);
+        expect(result.data.all).toBeUndefined();
+      }
+    });
+
+    it("parses with all: true", () => {
+      const result = markReadSchema.safeParse({ all: true });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.all).toBe(true);
+        expect(result.data.notificationId).toBeUndefined();
+      }
+    });
+
+    it("parses with both notificationId and all", () => {
+      const result = markReadSchema.safeParse({
+        notificationId: 1,
+        all: true,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("parses empty object (both optional)", () => {
+      const result = markReadSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.notificationId).toBeUndefined();
+        expect(result.data.all).toBeUndefined();
+      }
+    });
+
+    it("fails for negative notificationId", () => {
+      const result = markReadSchema.safeParse({ notificationId: -1 });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for zero notificationId", () => {
+      const result = markReadSchema.safeParse({ notificationId: 0 });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for non-integer notificationId", () => {
+      const result = markReadSchema.safeParse({ notificationId: 1.5 });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for non-boolean all", () => {
+      const result = markReadSchema.safeParse({ all: "yes" });
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `notifications` table (recipient, type, subject, actor, read status, community)
- `GET /api/notifications` -- paginated list, unread-first ordering, cursor-based pagination
- `PUT /api/notifications/read` -- mark single notification or all as read
- `GET /api/notifications/count` -- unread count for UI badge display
- All endpoints require authentication, include OpenAPI schema annotations
- 43 new tests (707 total), all passing

## Test plan

- [x] Schema tests: table name, columns, primary key, not-null, defaults
- [x] Validation tests: query params, mark-read body, defaults, edge cases
- [x] Route tests: 401 unauthenticated, empty list, ordering, pagination
- [x] Route tests: mark single read, mark all read, 400 on invalid body
- [x] Route tests: unread count, zero count
- [x] All 707 tests pass, lint clean, typecheck clean