### PR TITLE
feat(api): add user profiles, reputation, and preferences (M10)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     "./src/db/schema/moderation-actions.ts",
     "./src/db/schema/reports.ts",
     "./src/db/schema/notifications.ts",
+    "./src/db/schema/user-preferences.ts",
   ],
   out: "./drizzle",
   dialect: "postgresql",

--- a/drizzle/0012_swift_tony_stark.sql
+++ b/drizzle/0012_swift_tony_stark.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "user_community_preferences" (
+	"did" text NOT NULL,
+	"community_did" text NOT NULL,
+	"maturity_override" text,
+	"muted_words" jsonb,
+	"blocked_dids" jsonb,
+	"muted_dids" jsonb,
+	"notification_prefs" jsonb,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_community_preferences_did_community_did_pk" PRIMARY KEY("did","community_did")
+);
+--> statement-breakpoint
+CREATE TABLE "user_preferences" (
+	"did" text PRIMARY KEY NOT NULL,
+	"maturity_level" text DEFAULT 'sfw' NOT NULL,
+	"age_declaration_at" timestamp with time zone,
+	"muted_words" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"blocked_dids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"muted_dids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"cross_post_bluesky" boolean DEFAULT false NOT NULL,
+	"cross_post_frontpage" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "user_community_prefs_did_idx" ON "user_community_preferences" USING btree ("did");--> statement-breakpoint
+CREATE INDEX "user_community_prefs_community_idx" ON "user_community_preferences" USING btree ("community_did");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1563 @@
+{
+  "id": "7babb9df-a29e-46f1-9f2e-b51b983e345a",
+  "prevId": "577fe24e-9352-49cb-af6e-444ad3f0a3d7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_score": {
+          "name": "reputation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "age_declared_at": {
+          "name": "age_declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturity_pref": {
+          "name": "maturity_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firehose_cursor": {
+      "name": "firehose_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_mod_deleted": {
+          "name": "is_mod_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "topics_author_did_idx": {
+          "name": "topics_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_category_idx": {
+          "name": "topics_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_created_at_idx": {
+          "name": "topics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_last_activity_at_idx": {
+          "name": "topics_last_activity_at_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_community_did_idx": {
+          "name": "topics_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replies": {
+      "name": "replies",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cid": {
+          "name": "root_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_uri": {
+          "name": "parent_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_cid": {
+          "name": "parent_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replies_author_did_idx": {
+          "name": "replies_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_root_uri_idx": {
+          "name": "replies_root_uri_idx",
+          "columns": [
+            {
+              "expression": "root_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_parent_uri_idx": {
+          "name": "replies_parent_uri_idx",
+          "columns": [
+            {
+              "expression": "parent_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_created_at_idx": {
+          "name": "replies_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_community_did_idx": {
+          "name": "replies_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_cid": {
+          "name": "subject_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_author_did_idx": {
+          "name": "reactions_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_subject_uri_idx": {
+          "name": "reactions_subject_uri_idx",
+          "columns": [
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_community_did_idx": {
+          "name": "reactions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_author_subject_type_uniq": {
+          "name": "reactions_author_subject_type_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_did",
+            "subject_uri",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tracked_at": {
+          "name": "tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "initialized": {
+          "name": "initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_did": {
+          "name": "admin_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_name": {
+          "name": "community_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Barazo Community'"
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "reaction_set": {
+          "name": "reaction_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"like\"]'::jsonb"
+        },
+        "moderation_thresholds": {
+          "name": "moderation_thresholds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"autoBlockReportCount\":5,\"warnThreshold\":3}'::jsonb"
+        },
+        "word_filter": {
+          "name": "word_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_community_did_idx": {
+          "name": "categories_slug_community_did_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_parent_id_idx": {
+          "name": "categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_community_did_idx": {
+          "name": "categories_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_maturity_rating_idx": {
+          "name": "categories_maturity_rating_idx",
+          "columns": [
+            {
+              "expression": "maturity_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_fk": {
+          "name": "categories_parent_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_did": {
+          "name": "moderator_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_actions_moderator_did_idx": {
+          "name": "mod_actions_moderator_did_idx",
+          "columns": [
+            {
+              "expression": "moderator_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_community_did_idx": {
+          "name": "mod_actions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_created_at_idx": {
+          "name": "mod_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_uri_idx": {
+          "name": "mod_actions_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_did_idx": {
+          "name": "mod_actions_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_did": {
+          "name": "reporter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_type": {
+          "name": "reason_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution_type": {
+          "name": "resolution_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_reporter_did_idx": {
+          "name": "reports_reporter_did_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_uri_idx": {
+          "name": "reports_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_did_idx": {
+          "name": "reports_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_community_did_idx": {
+          "name": "reports_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_unique_reporter_target_idx": {
+          "name": "reports_unique_reporter_target_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_did": {
+          "name": "recipient_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_did": {
+          "name": "actor_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_did_idx": {
+          "name": "notifications_recipient_did_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_community_preferences": {
+      "name": "user_community_preferences",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_override": {
+          "name": "maturity_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_words": {
+          "name": "muted_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_dids": {
+          "name": "blocked_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_dids": {
+          "name": "muted_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_prefs": {
+          "name": "notification_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_community_prefs_did_idx": {
+          "name": "user_community_prefs_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_community_prefs_community_idx": {
+          "name": "user_community_prefs_community_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_community_preferences_did_community_did_pk": {
+          "name": "user_community_preferences_did_community_did_pk",
+          "columns": [
+            "did",
+            "community_did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "maturity_level": {
+          "name": "maturity_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sfw'"
+        },
+        "age_declaration_at": {
+          "name": "age_declaration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_words": {
+          "name": "muted_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_dids": {
+          "name": "blocked_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "muted_dids": {
+          "name": "muted_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cross_post_bluesky": {
+          "name": "cross_post_bluesky",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cross_post_frontpage": {
+          "name": "cross_post_frontpage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1771037848181,
       "tag": "0011_fresh_veda",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1771038512722,
+      "tag": "0012_swift_tony_stark",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ import { reactionRoutes } from "./routes/reactions.js";
 import { moderationRoutes } from "./routes/moderation.js";
 import { searchRoutes } from "./routes/search.js";
 import { notificationRoutes } from "./routes/notifications.js";
+import { profileRoutes } from "./routes/profiles.js";
 import { createRequireAdmin } from "./auth/require-admin.js";
 import { createSetupService } from "./setup/service.js";
 import type { SetupService } from "./setup/service.js";
@@ -195,6 +196,7 @@ export async function buildApp(env: Env) {
   await app.register(moderationRoutes());
   await app.register(searchRoutes());
   await app.register(notificationRoutes());
+  await app.register(profileRoutes());
 
   // OpenAPI spec endpoint (after routes so all schemas are registered)
   app.get("/api/openapi.json", { schema: { hide: true } }, async (_request, reply) => {

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -9,3 +9,4 @@ export { categories } from "./categories.js";
 export { moderationActions } from "./moderation-actions.js";
 export { reports } from "./reports.js";
 export { notifications } from "./notifications.js";
+export { userPreferences, userCommunityPreferences } from "./user-preferences.js";

--- a/src/db/schema/user-preferences.ts
+++ b/src/db/schema/user-preferences.ts
@@ -1,0 +1,63 @@
+import {
+  pgTable,
+  text,
+  timestamp,
+  jsonb,
+  boolean,
+  index,
+  primaryKey,
+} from "drizzle-orm/pg-core";
+
+// ---------------------------------------------------------------------------
+// Global user preferences (stored in PostgreSQL for MVP, will sync to PDS later)
+// ---------------------------------------------------------------------------
+
+export const userPreferences = pgTable("user_preferences", {
+  did: text("did").primaryKey(),
+  maturityLevel: text("maturity_level", {
+    enum: ["sfw", "mature"],
+  })
+    .notNull()
+    .default("sfw"),
+  ageDeclarationAt: timestamp("age_declaration_at", { withTimezone: true }),
+  mutedWords: jsonb("muted_words").$type<string[]>().notNull().default([]),
+  blockedDids: jsonb("blocked_dids").$type<string[]>().notNull().default([]),
+  mutedDids: jsonb("muted_dids").$type<string[]>().notNull().default([]),
+  crossPostBluesky: boolean("cross_post_bluesky").notNull().default(false),
+  crossPostFrontpage: boolean("cross_post_frontpage").notNull().default(false),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+// ---------------------------------------------------------------------------
+// Per-community preference overrides
+// ---------------------------------------------------------------------------
+
+export const userCommunityPreferences = pgTable(
+  "user_community_preferences",
+  {
+    did: text("did").notNull(),
+    communityDid: text("community_did").notNull(),
+    maturityOverride: text("maturity_override", {
+      enum: ["sfw", "mature"],
+    }),
+    mutedWords: jsonb("muted_words").$type<string[]>(),
+    blockedDids: jsonb("blocked_dids").$type<string[]>(),
+    mutedDids: jsonb("muted_dids").$type<string[]>(),
+    notificationPrefs: jsonb("notification_prefs").$type<{
+      replies: boolean;
+      reactions: boolean;
+      mentions: boolean;
+      modActions: boolean;
+    }>(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.did, table.communityDid] }),
+    index("user_community_prefs_did_idx").on(table.did),
+    index("user_community_prefs_community_idx").on(table.communityDid),
+  ],
+);

--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -1,0 +1,864 @@
+import { eq, and, sql } from "drizzle-orm";
+import type { FastifyPluginCallback } from "fastify";
+import { notFound, badRequest } from "../lib/api-errors.js";
+import {
+  userPreferencesSchema,
+  communityPreferencesSchema,
+  ageDeclarationSchema,
+} from "../validation/profiles.js";
+import { users } from "../db/schema/users.js";
+import { topics } from "../db/schema/topics.js";
+import { replies } from "../db/schema/replies.js";
+import { reactions } from "../db/schema/reactions.js";
+import { notifications } from "../db/schema/notifications.js";
+import { reports } from "../db/schema/reports.js";
+import {
+  userPreferences,
+  userCommunityPreferences,
+} from "../db/schema/user-preferences.js";
+
+// ---------------------------------------------------------------------------
+// OpenAPI JSON Schema definitions
+// ---------------------------------------------------------------------------
+
+const errorJsonSchema = {
+  type: "object" as const,
+  properties: {
+    error: { type: "string" as const },
+  },
+};
+
+const profileJsonSchema = {
+  type: "object" as const,
+  properties: {
+    did: { type: "string" as const },
+    handle: { type: "string" as const },
+    displayName: { type: ["string", "null"] as const },
+    avatarUrl: { type: ["string", "null"] as const },
+    role: { type: "string" as const },
+    firstSeenAt: { type: "string" as const, format: "date-time" as const },
+    lastActiveAt: { type: "string" as const, format: "date-time" as const },
+    activity: {
+      type: "object" as const,
+      properties: {
+        topicCount: { type: "number" as const },
+        replyCount: { type: "number" as const },
+        reactionsReceived: { type: "number" as const },
+      },
+    },
+  },
+};
+
+const reputationJsonSchema = {
+  type: "object" as const,
+  properties: {
+    did: { type: "string" as const },
+    handle: { type: "string" as const },
+    reputation: { type: "number" as const },
+    breakdown: {
+      type: "object" as const,
+      properties: {
+        topicCount: { type: "number" as const },
+        replyCount: { type: "number" as const },
+        reactionsReceived: { type: "number" as const },
+      },
+    },
+  },
+};
+
+const preferencesJsonSchema = {
+  type: "object" as const,
+  properties: {
+    maturityLevel: { type: "string" as const },
+    ageDeclarationAt: {
+      type: ["string", "null"] as const,
+      format: "date-time" as const,
+    },
+    mutedWords: { type: "array" as const, items: { type: "string" as const } },
+    blockedDids: {
+      type: "array" as const,
+      items: { type: "string" as const },
+    },
+    mutedDids: { type: "array" as const, items: { type: "string" as const } },
+    crossPostBluesky: { type: "boolean" as const },
+    crossPostFrontpage: { type: "boolean" as const },
+    updatedAt: { type: "string" as const, format: "date-time" as const },
+  },
+};
+
+const communityPrefsJsonSchema = {
+  type: "object" as const,
+  properties: {
+    communityDid: { type: "string" as const },
+    maturityOverride: { type: ["string", "null"] as const },
+    mutedWords: {
+      type: ["array", "null"] as const,
+      items: { type: "string" as const },
+    },
+    blockedDids: {
+      type: ["array", "null"] as const,
+      items: { type: "string" as const },
+    },
+    mutedDids: {
+      type: ["array", "null"] as const,
+      items: { type: "string" as const },
+    },
+    notificationPrefs: {
+      type: ["object", "null"] as const,
+      properties: {
+        replies: { type: "boolean" as const },
+        reactions: { type: "boolean" as const },
+        mentions: { type: "boolean" as const },
+        modActions: { type: "boolean" as const },
+      },
+    },
+    updatedAt: { type: "string" as const, format: "date-time" as const },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default global preferences returned when no row exists yet. */
+function defaultPreferences() {
+  return {
+    maturityLevel: "sfw" as const,
+    ageDeclarationAt: null,
+    mutedWords: [] as string[],
+    blockedDids: [] as string[],
+    mutedDids: [] as string[],
+    crossPostBluesky: false,
+    crossPostFrontpage: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Default per-community preferences returned when no row exists yet. */
+function defaultCommunityPreferences(communityDid: string) {
+  return {
+    communityDid,
+    maturityOverride: null,
+    mutedWords: null,
+    blockedDids: null,
+    mutedDids: null,
+    notificationPrefs: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Profile routes plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * Profile, reputation, and preferences routes for the Barazo forum.
+ *
+ * - GET    /api/users/:handle                              -- Public profile
+ * - GET    /api/users/:handle/reputation                   -- Reputation score
+ * - POST   /api/users/me/age-declaration                   -- Declare age
+ * - GET    /api/users/me/preferences                       -- Global preferences
+ * - PUT    /api/users/me/preferences                       -- Update global preferences
+ * - GET    /api/users/me/communities/:communityId/preferences -- Per-community prefs
+ * - PUT    /api/users/me/communities/:communityId/preferences -- Update per-community prefs
+ * - DELETE /api/users/me                                   -- GDPR Art. 17 purge
+ */
+export function profileRoutes(): FastifyPluginCallback {
+  return (app, _opts, done) => {
+    const { db, authMiddleware } = app;
+
+    // -------------------------------------------------------------------
+    // GET /api/users/:handle (public, optionalAuth)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/users/:handle",
+      {
+        preHandler: [authMiddleware.optionalAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Get user profile and activity summary",
+          params: {
+            type: "object",
+            required: ["handle"],
+            properties: {
+              handle: { type: "string" },
+            },
+          },
+          response: {
+            200: profileJsonSchema,
+            404: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { handle } = request.params as { handle: string };
+
+        // Look up user by handle
+        const userRows = await db
+          .select()
+          .from(users)
+          .where(eq(users.handle, handle));
+
+        const user = userRows[0];
+        if (!user) {
+          throw notFound("User not found");
+        }
+
+        // Aggregate activity counts
+        const topicCountResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(topics)
+          .where(eq(topics.authorDid, user.did));
+
+        const replyCountResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(replies)
+          .where(eq(replies.authorDid, user.did));
+
+        // Count reactions received on user's topics and replies
+        const reactionsOnTopicsResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reactions)
+          .where(
+            sql`${reactions.subjectUri} IN (SELECT ${topics.uri} FROM ${topics} WHERE ${topics.authorDid} = ${user.did})`,
+          );
+
+        const reactionsOnRepliesResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reactions)
+          .where(
+            sql`${reactions.subjectUri} IN (SELECT ${replies.uri} FROM ${replies} WHERE ${replies.authorDid} = ${user.did})`,
+          );
+
+        const topicCount = topicCountResult[0]?.count ?? 0;
+        const replyCount = replyCountResult[0]?.count ?? 0;
+        const reactionsReceived =
+          (reactionsOnTopicsResult[0]?.count ?? 0) +
+          (reactionsOnRepliesResult[0]?.count ?? 0);
+
+        return reply.status(200).send({
+          did: user.did,
+          handle: user.handle,
+          displayName: user.displayName ?? null,
+          avatarUrl: user.avatarUrl ?? null,
+          role: user.role,
+          firstSeenAt: user.firstSeenAt.toISOString(),
+          lastActiveAt: user.lastActiveAt.toISOString(),
+          activity: {
+            topicCount,
+            replyCount,
+            reactionsReceived,
+          },
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // GET /api/users/:handle/reputation (public)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/users/:handle/reputation",
+      {
+        preHandler: [authMiddleware.optionalAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Get user reputation score",
+          params: {
+            type: "object",
+            required: ["handle"],
+            properties: {
+              handle: { type: "string" },
+            },
+          },
+          response: {
+            200: reputationJsonSchema,
+            404: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const { handle } = request.params as { handle: string };
+
+        // Look up user by handle
+        const userRows = await db
+          .select()
+          .from(users)
+          .where(eq(users.handle, handle));
+
+        const user = userRows[0];
+        if (!user) {
+          throw notFound("User not found");
+        }
+
+        // Count topics
+        const topicCountResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(topics)
+          .where(eq(topics.authorDid, user.did));
+
+        // Count replies
+        const replyCountResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(replies)
+          .where(eq(replies.authorDid, user.did));
+
+        // Count reactions received
+        const reactionsOnTopicsResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reactions)
+          .where(
+            sql`${reactions.subjectUri} IN (SELECT ${topics.uri} FROM ${topics} WHERE ${topics.authorDid} = ${user.did})`,
+          );
+
+        const reactionsOnRepliesResult = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(reactions)
+          .where(
+            sql`${reactions.subjectUri} IN (SELECT ${replies.uri} FROM ${replies} WHERE ${replies.authorDid} = ${user.did})`,
+          );
+
+        const topicCount = topicCountResult[0]?.count ?? 0;
+        const replyCount = replyCountResult[0]?.count ?? 0;
+        const reactionsReceived =
+          (reactionsOnTopicsResult[0]?.count ?? 0) +
+          (reactionsOnRepliesResult[0]?.count ?? 0);
+
+        // Reputation formula: (topics * 5) + (replies * 2) + (reactions_received * 1)
+        const reputation =
+          topicCount * 5 + replyCount * 2 + reactionsReceived * 1;
+
+        return reply.status(200).send({
+          did: user.did,
+          handle: user.handle,
+          reputation,
+          breakdown: {
+            topicCount,
+            replyCount,
+            reactionsReceived,
+          },
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // POST /api/users/me/age-declaration (auth required)
+    // -------------------------------------------------------------------
+
+    app.post(
+      "/api/users/me/age-declaration",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Declare age to unlock mature content access",
+          security: [{ bearerAuth: [] }],
+          body: {
+            type: "object",
+            required: ["confirm"],
+            properties: {
+              confirm: { type: "boolean", enum: [true] },
+            },
+          },
+          response: {
+            200: {
+              type: "object",
+              properties: {
+                success: { type: "boolean" },
+                ageDeclarationAt: {
+                  type: "string",
+                  format: "date-time",
+                },
+              },
+            },
+            400: errorJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const parsed = ageDeclarationSchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest("Body must include confirm: true");
+        }
+
+        const now = new Date();
+
+        // Upsert into user_preferences
+        await db
+          .insert(userPreferences)
+          .values({
+            did: requestUser.did,
+            ageDeclarationAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: userPreferences.did,
+            set: {
+              ageDeclarationAt: now,
+              updatedAt: now,
+            },
+          });
+
+        return reply.status(200).send({
+          success: true,
+          ageDeclarationAt: now.toISOString(),
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // GET /api/users/me/preferences (auth required)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/users/me/preferences",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Get global user preferences",
+          security: [{ bearerAuth: [] }],
+          response: {
+            200: preferencesJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const rows = await db
+          .select()
+          .from(userPreferences)
+          .where(eq(userPreferences.did, requestUser.did));
+
+        const prefs = rows[0];
+        if (!prefs) {
+          return reply.status(200).send(defaultPreferences());
+        }
+
+        return reply.status(200).send({
+          maturityLevel: prefs.maturityLevel,
+          ageDeclarationAt: prefs.ageDeclarationAt?.toISOString() ?? null,
+          mutedWords: prefs.mutedWords,
+          blockedDids: prefs.blockedDids,
+          mutedDids: prefs.mutedDids,
+          crossPostBluesky: prefs.crossPostBluesky,
+          crossPostFrontpage: prefs.crossPostFrontpage,
+          updatedAt: prefs.updatedAt.toISOString(),
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // PUT /api/users/me/preferences (auth required)
+    // -------------------------------------------------------------------
+
+    app.put(
+      "/api/users/me/preferences",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Update global user preferences",
+          security: [{ bearerAuth: [] }],
+          body: {
+            type: "object",
+            properties: {
+              maturityLevel: { type: "string", enum: ["sfw", "mature"] },
+              mutedWords: {
+                type: "array",
+                items: { type: "string" },
+              },
+              blockedDids: {
+                type: "array",
+                items: { type: "string" },
+              },
+              mutedDids: {
+                type: "array",
+                items: { type: "string" },
+              },
+              crossPostBluesky: { type: "boolean" },
+              crossPostFrontpage: { type: "boolean" },
+            },
+          },
+          response: {
+            200: preferencesJsonSchema,
+            400: errorJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const parsed = userPreferencesSchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest("Invalid preferences data");
+        }
+
+        const now = new Date();
+        const updateData: Record<string, unknown> = { updatedAt: now };
+
+        if (parsed.data.maturityLevel !== undefined) {
+          updateData["maturityLevel"] = parsed.data.maturityLevel;
+        }
+        if (parsed.data.mutedWords !== undefined) {
+          updateData["mutedWords"] = parsed.data.mutedWords;
+        }
+        if (parsed.data.blockedDids !== undefined) {
+          updateData["blockedDids"] = parsed.data.blockedDids;
+        }
+        if (parsed.data.mutedDids !== undefined) {
+          updateData["mutedDids"] = parsed.data.mutedDids;
+        }
+        if (parsed.data.crossPostBluesky !== undefined) {
+          updateData["crossPostBluesky"] = parsed.data.crossPostBluesky;
+        }
+        if (parsed.data.crossPostFrontpage !== undefined) {
+          updateData["crossPostFrontpage"] = parsed.data.crossPostFrontpage;
+        }
+
+        // Upsert
+        await db
+          .insert(userPreferences)
+          .values({
+            did: requestUser.did,
+            ...parsed.data,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: userPreferences.did,
+            set: updateData,
+          });
+
+        // Fetch the updated row
+        const rows = await db
+          .select()
+          .from(userPreferences)
+          .where(eq(userPreferences.did, requestUser.did));
+
+        const prefs = rows[0];
+        if (!prefs) {
+          return reply.status(200).send(defaultPreferences());
+        }
+
+        return reply.status(200).send({
+          maturityLevel: prefs.maturityLevel,
+          ageDeclarationAt: prefs.ageDeclarationAt?.toISOString() ?? null,
+          mutedWords: prefs.mutedWords,
+          blockedDids: prefs.blockedDids,
+          mutedDids: prefs.mutedDids,
+          crossPostBluesky: prefs.crossPostBluesky,
+          crossPostFrontpage: prefs.crossPostFrontpage,
+          updatedAt: prefs.updatedAt.toISOString(),
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // GET /api/users/me/communities/:communityId/preferences (auth required)
+    // -------------------------------------------------------------------
+
+    app.get(
+      "/api/users/me/communities/:communityId/preferences",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Get per-community user preferences",
+          security: [{ bearerAuth: [] }],
+          params: {
+            type: "object",
+            required: ["communityId"],
+            properties: {
+              communityId: { type: "string" },
+            },
+          },
+          response: {
+            200: communityPrefsJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const { communityId } = request.params as { communityId: string };
+
+        const rows = await db
+          .select()
+          .from(userCommunityPreferences)
+          .where(
+            and(
+              eq(userCommunityPreferences.did, requestUser.did),
+              eq(userCommunityPreferences.communityDid, communityId),
+            ),
+          );
+
+        const prefs = rows[0];
+        if (!prefs) {
+          return reply
+            .status(200)
+            .send(defaultCommunityPreferences(communityId));
+        }
+
+        return reply.status(200).send({
+          communityDid: prefs.communityDid,
+          maturityOverride: prefs.maturityOverride ?? null,
+          mutedWords: prefs.mutedWords ?? null,
+          blockedDids: prefs.blockedDids ?? null,
+          mutedDids: prefs.mutedDids ?? null,
+          notificationPrefs: prefs.notificationPrefs ?? null,
+          updatedAt: prefs.updatedAt.toISOString(),
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // PUT /api/users/me/communities/:communityId/preferences (auth required)
+    // -------------------------------------------------------------------
+
+    app.put(
+      "/api/users/me/communities/:communityId/preferences",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary: "Update per-community user preferences",
+          security: [{ bearerAuth: [] }],
+          params: {
+            type: "object",
+            required: ["communityId"],
+            properties: {
+              communityId: { type: "string" },
+            },
+          },
+          body: {
+            type: "object",
+            properties: {
+              maturityOverride: {
+                type: ["string", "null"],
+                enum: ["sfw", "mature", null],
+              },
+              mutedWords: {
+                type: ["array", "null"],
+                items: { type: "string" },
+              },
+              blockedDids: {
+                type: ["array", "null"],
+                items: { type: "string" },
+              },
+              mutedDids: {
+                type: ["array", "null"],
+                items: { type: "string" },
+              },
+              notificationPrefs: {
+                type: ["object", "null"],
+                properties: {
+                  replies: { type: "boolean" },
+                  reactions: { type: "boolean" },
+                  mentions: { type: "boolean" },
+                  modActions: { type: "boolean" },
+                },
+              },
+            },
+          },
+          response: {
+            200: communityPrefsJsonSchema,
+            400: errorJsonSchema,
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const { communityId } = request.params as { communityId: string };
+
+        const parsed = communityPreferencesSchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest("Invalid community preferences data");
+        }
+
+        const now = new Date();
+        const updateData: Record<string, unknown> = { updatedAt: now };
+
+        if (parsed.data.maturityOverride !== undefined) {
+          updateData["maturityOverride"] = parsed.data.maturityOverride;
+        }
+        if (parsed.data.mutedWords !== undefined) {
+          updateData["mutedWords"] = parsed.data.mutedWords;
+        }
+        if (parsed.data.blockedDids !== undefined) {
+          updateData["blockedDids"] = parsed.data.blockedDids;
+        }
+        if (parsed.data.mutedDids !== undefined) {
+          updateData["mutedDids"] = parsed.data.mutedDids;
+        }
+        if (parsed.data.notificationPrefs !== undefined) {
+          updateData["notificationPrefs"] = parsed.data.notificationPrefs;
+        }
+
+        // Upsert: use composite key (did, communityDid)
+        await db
+          .insert(userCommunityPreferences)
+          .values({
+            did: requestUser.did,
+            communityDid: communityId,
+            ...parsed.data,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: [
+              userCommunityPreferences.did,
+              userCommunityPreferences.communityDid,
+            ],
+            set: updateData,
+          });
+
+        // Fetch updated row
+        const rows = await db
+          .select()
+          .from(userCommunityPreferences)
+          .where(
+            and(
+              eq(userCommunityPreferences.did, requestUser.did),
+              eq(userCommunityPreferences.communityDid, communityId),
+            ),
+          );
+
+        const prefs = rows[0];
+        if (!prefs) {
+          return reply
+            .status(200)
+            .send(defaultCommunityPreferences(communityId));
+        }
+
+        return reply.status(200).send({
+          communityDid: prefs.communityDid,
+          maturityOverride: prefs.maturityOverride ?? null,
+          mutedWords: prefs.mutedWords ?? null,
+          blockedDids: prefs.blockedDids ?? null,
+          mutedDids: prefs.mutedDids ?? null,
+          notificationPrefs: prefs.notificationPrefs ?? null,
+          updatedAt: prefs.updatedAt.toISOString(),
+        });
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // DELETE /api/users/me (auth required) -- GDPR Art. 17 purge
+    // -------------------------------------------------------------------
+
+    app.delete(
+      "/api/users/me",
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ["Profiles"],
+          summary:
+            "Delete all indexed data for the authenticated user (GDPR Art. 17)",
+          security: [{ bearerAuth: [] }],
+          response: {
+            204: { type: "null" },
+            401: errorJsonSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user;
+        if (!requestUser) {
+          return reply
+            .status(401)
+            .send({ error: "Authentication required" });
+        }
+
+        const userDid = requestUser.did;
+
+        await db.transaction(async (tx) => {
+          // Delete reactions by this user
+          await tx
+            .delete(reactions)
+            .where(eq(reactions.authorDid, userDid));
+
+          // Delete notifications for/by this user
+          await tx
+            .delete(notifications)
+            .where(eq(notifications.recipientDid, userDid));
+          await tx
+            .delete(notifications)
+            .where(eq(notifications.actorDid, userDid));
+
+          // Delete reports filed by this user
+          await tx
+            .delete(reports)
+            .where(eq(reports.reporterDid, userDid));
+
+          // Delete replies by this user
+          await tx
+            .delete(replies)
+            .where(eq(replies.authorDid, userDid));
+
+          // Delete topics by this user
+          await tx
+            .delete(topics)
+            .where(eq(topics.authorDid, userDid));
+
+          // Delete community preferences
+          await tx
+            .delete(userCommunityPreferences)
+            .where(eq(userCommunityPreferences.did, userDid));
+
+          // Delete global preferences
+          await tx
+            .delete(userPreferences)
+            .where(eq(userPreferences.did, userDid));
+
+          // Delete user record
+          await tx
+            .delete(users)
+            .where(eq(users.did, userDid));
+        });
+
+        app.log.info(
+          { did: userDid },
+          "GDPR Art. 17: all indexed data purged for user",
+        );
+
+        return reply.status(204).send();
+      },
+    );
+
+    done();
+  };
+}

--- a/src/validation/profiles.ts
+++ b/src/validation/profiles.ts
@@ -1,0 +1,73 @@
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Body schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for PUT /api/users/me/preferences body. */
+export const userPreferencesSchema = z.object({
+  maturityLevel: z
+    .enum(["sfw", "mature"])
+    .optional(),
+  mutedWords: z
+    .array(z.string().min(1).max(200))
+    .max(500)
+    .optional(),
+  blockedDids: z
+    .array(z.string().min(1))
+    .max(1000)
+    .optional(),
+  mutedDids: z
+    .array(z.string().min(1))
+    .max(1000)
+    .optional(),
+  crossPostBluesky: z
+    .boolean()
+    .optional(),
+  crossPostFrontpage: z
+    .boolean()
+    .optional(),
+});
+
+export type UserPreferencesInput = z.infer<typeof userPreferencesSchema>;
+
+/** Schema for PUT /api/users/me/communities/:communityId/preferences body. */
+export const communityPreferencesSchema = z.object({
+  maturityOverride: z
+    .enum(["sfw", "mature"])
+    .nullable()
+    .optional(),
+  mutedWords: z
+    .array(z.string().min(1).max(200))
+    .max(500)
+    .nullable()
+    .optional(),
+  blockedDids: z
+    .array(z.string().min(1))
+    .max(1000)
+    .nullable()
+    .optional(),
+  mutedDids: z
+    .array(z.string().min(1))
+    .max(1000)
+    .nullable()
+    .optional(),
+  notificationPrefs: z
+    .object({
+      replies: z.boolean(),
+      reactions: z.boolean(),
+      mentions: z.boolean(),
+      modActions: z.boolean(),
+    })
+    .nullable()
+    .optional(),
+});
+
+export type CommunityPreferencesInput = z.infer<typeof communityPreferencesSchema>;
+
+/** Schema for POST /api/users/me/age-declaration body. */
+export const ageDeclarationSchema = z.object({
+  confirm: z.literal(true),
+});
+
+export type AgeDeclarationInput = z.infer<typeof ageDeclarationSchema>;

--- a/tests/unit/db/schema/user-preferences.test.ts
+++ b/tests/unit/db/schema/user-preferences.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  userPreferences,
+  userCommunityPreferences,
+} from "../../../../src/db/schema/user-preferences.js";
+import { getTableName, getTableColumns } from "drizzle-orm";
+
+// ===========================================================================
+// userPreferences schema
+// ===========================================================================
+
+describe("userPreferences schema", () => {
+  it("should have the correct table name", () => {
+    expect(getTableName(userPreferences)).toBe("user_preferences");
+  });
+
+  it("should have all required columns", () => {
+    const columns = getTableColumns(userPreferences);
+    const columnNames = Object.keys(columns);
+
+    expect(columnNames).toContain("did");
+    expect(columnNames).toContain("maturityLevel");
+    expect(columnNames).toContain("ageDeclarationAt");
+    expect(columnNames).toContain("mutedWords");
+    expect(columnNames).toContain("blockedDids");
+    expect(columnNames).toContain("mutedDids");
+    expect(columnNames).toContain("crossPostBluesky");
+    expect(columnNames).toContain("crossPostFrontpage");
+    expect(columnNames).toContain("updatedAt");
+  });
+
+  it("should have did as primary key", () => {
+    const columns = getTableColumns(userPreferences);
+    expect(columns.did.primary).toBe(true);
+  });
+
+  it("should mark required columns as not null", () => {
+    const columns = getTableColumns(userPreferences);
+    expect(columns.did.notNull).toBe(true);
+    expect(columns.maturityLevel.notNull).toBe(true);
+    expect(columns.mutedWords.notNull).toBe(true);
+    expect(columns.blockedDids.notNull).toBe(true);
+    expect(columns.mutedDids.notNull).toBe(true);
+    expect(columns.crossPostBluesky.notNull).toBe(true);
+    expect(columns.crossPostFrontpage.notNull).toBe(true);
+    expect(columns.updatedAt.notNull).toBe(true);
+  });
+
+  it("should allow ageDeclarationAt to be nullable", () => {
+    const columns = getTableColumns(userPreferences);
+    expect(columns.ageDeclarationAt.notNull).toBe(false);
+  });
+
+  it("should have exactly 9 columns", () => {
+    const columns = getTableColumns(userPreferences);
+    expect(Object.keys(columns)).toHaveLength(9);
+  });
+
+  it("should have default values for maturityLevel, mutedWords, blockedDids, mutedDids, crossPost*, updatedAt", () => {
+    const columns = getTableColumns(userPreferences);
+    expect(columns.maturityLevel.hasDefault).toBe(true);
+    expect(columns.mutedWords.hasDefault).toBe(true);
+    expect(columns.blockedDids.hasDefault).toBe(true);
+    expect(columns.mutedDids.hasDefault).toBe(true);
+    expect(columns.crossPostBluesky.hasDefault).toBe(true);
+    expect(columns.crossPostFrontpage.hasDefault).toBe(true);
+    expect(columns.updatedAt.hasDefault).toBe(true);
+  });
+});
+
+// ===========================================================================
+// userCommunityPreferences schema
+// ===========================================================================
+
+describe("userCommunityPreferences schema", () => {
+  it("should have the correct table name", () => {
+    expect(getTableName(userCommunityPreferences)).toBe(
+      "user_community_preferences",
+    );
+  });
+
+  it("should have all required columns", () => {
+    const columns = getTableColumns(userCommunityPreferences);
+    const columnNames = Object.keys(columns);
+
+    expect(columnNames).toContain("did");
+    expect(columnNames).toContain("communityDid");
+    expect(columnNames).toContain("maturityOverride");
+    expect(columnNames).toContain("mutedWords");
+    expect(columnNames).toContain("blockedDids");
+    expect(columnNames).toContain("mutedDids");
+    expect(columnNames).toContain("notificationPrefs");
+    expect(columnNames).toContain("updatedAt");
+  });
+
+  it("should have exactly 8 columns", () => {
+    const columns = getTableColumns(userCommunityPreferences);
+    expect(Object.keys(columns)).toHaveLength(8);
+  });
+
+  it("should mark did and communityDid as not null", () => {
+    const columns = getTableColumns(userCommunityPreferences);
+    expect(columns.did.notNull).toBe(true);
+    expect(columns.communityDid.notNull).toBe(true);
+  });
+
+  it("should mark updatedAt as not null with default", () => {
+    const columns = getTableColumns(userCommunityPreferences);
+    expect(columns.updatedAt.notNull).toBe(true);
+    expect(columns.updatedAt.hasDefault).toBe(true);
+  });
+
+  it("should allow optional columns to be nullable", () => {
+    const columns = getTableColumns(userCommunityPreferences);
+    expect(columns.maturityOverride.notNull).toBe(false);
+    expect(columns.mutedWords.notNull).toBe(false);
+    expect(columns.blockedDids.notNull).toBe(false);
+    expect(columns.mutedDids.notNull).toBe(false);
+    expect(columns.notificationPrefs.notNull).toBe(false);
+  });
+});

--- a/tests/unit/routes/profiles.test.ts
+++ b/tests/unit/routes/profiles.test.ts
@@ -1,0 +1,827 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  vi,
+  beforeEach,
+} from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+import type { Env } from "../../../src/config/env.js";
+import type {
+  AuthMiddleware,
+  RequestUser,
+} from "../../../src/auth/middleware.js";
+import type { SessionService } from "../../../src/auth/session.js";
+import type { SetupService } from "../../../src/setup/service.js";
+import {
+  type DbChain,
+  createChainableProxy,
+  createMockDb,
+} from "../../helpers/mock-db.js";
+
+// Import routes
+import { profileRoutes } from "../../../src/routes/profiles.js";
+
+// ---------------------------------------------------------------------------
+// Mock env
+// ---------------------------------------------------------------------------
+
+const mockEnv = {
+  COMMUNITY_DID: "did:plc:community123",
+  RATE_LIMIT_WRITE: 10,
+  RATE_LIMIT_READ_ANON: 100,
+  RATE_LIMIT_READ_AUTH: 300,
+} as Env;
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_DID = "did:plc:testuser123";
+const TEST_HANDLE = "alice.bsky.social";
+const TEST_SID = "a".repeat(64);
+const COMMUNITY_DID = "did:plc:community123";
+const TEST_NOW = "2026-02-14T12:00:00.000Z";
+
+// ---------------------------------------------------------------------------
+// Mock user builders
+// ---------------------------------------------------------------------------
+
+function testUser(overrides?: Partial<RequestUser>): RequestUser {
+  return {
+    did: TEST_DID,
+    handle: TEST_HANDLE,
+    sid: TEST_SID,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sample data builders
+// ---------------------------------------------------------------------------
+
+function sampleUserRow(overrides?: Record<string, unknown>) {
+  return {
+    did: TEST_DID,
+    handle: TEST_HANDLE,
+    displayName: "Alice",
+    avatarUrl: "https://example.com/avatar.jpg",
+    role: "user",
+    isBanned: false,
+    reputationScore: 0,
+    firstSeenAt: new Date(TEST_NOW),
+    lastActiveAt: new Date(TEST_NOW),
+    ageDeclaredAt: null,
+    maturityPref: "safe",
+    ...overrides,
+  };
+}
+
+function samplePrefsRow(overrides?: Record<string, unknown>) {
+  return {
+    did: TEST_DID,
+    maturityLevel: "sfw",
+    ageDeclarationAt: null,
+    mutedWords: [],
+    blockedDids: [],
+    mutedDids: [],
+    crossPostBluesky: false,
+    crossPostFrontpage: false,
+    updatedAt: new Date(TEST_NOW),
+    ...overrides,
+  };
+}
+
+function sampleCommunityPrefsRow(overrides?: Record<string, unknown>) {
+  return {
+    did: TEST_DID,
+    communityDid: COMMUNITY_DID,
+    maturityOverride: null,
+    mutedWords: null,
+    blockedDids: null,
+    mutedDids: null,
+    notificationPrefs: null,
+    updatedAt: new Date(TEST_NOW),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Chainable mock DB
+// ---------------------------------------------------------------------------
+
+const mockDb = createMockDb();
+
+let selectChain: DbChain;
+let insertChain: DbChain;
+let deleteChain: DbChain;
+
+function resetAllDbMocks(): void {
+  selectChain = createChainableProxy([]);
+  insertChain = createChainableProxy();
+  deleteChain = createChainableProxy();
+  mockDb.insert.mockReturnValue(insertChain);
+  mockDb.select.mockReturnValue(selectChain);
+  mockDb.update.mockReturnValue(createChainableProxy([]));
+  mockDb.delete.mockReturnValue(deleteChain);
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Intentionally async mock for Drizzle transaction
+  mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockDb) => Promise<unknown>) => {
+    return await fn(mockDb);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware mocks
+// ---------------------------------------------------------------------------
+
+function createMockAuthMiddleware(user?: RequestUser): AuthMiddleware {
+  return {
+    requireAuth: async (request, reply) => {
+      if (!user) {
+        await reply.status(401).send({ error: "Authentication required" });
+        return;
+      }
+      request.user = user;
+    },
+    optionalAuth: (request, _reply) => {
+      if (user) {
+        request.user = user;
+      }
+      return Promise.resolve();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build app with mocked deps
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  app.decorate("db", mockDb as never);
+  app.decorate("env", mockEnv);
+  app.decorate("authMiddleware", createMockAuthMiddleware(user));
+  app.decorate("firehose", {} as never);
+  app.decorate("oauthClient", {} as never);
+  app.decorate("sessionService", {} as SessionService);
+  app.decorate("setupService", {} as SetupService);
+  app.decorate("cache", {} as never);
+  app.decorateRequest("user", undefined as RequestUser | undefined);
+
+  // Override the logger so we can capture log calls
+  app.log.info = mockLogger.info;
+  app.log.warn = mockLogger.warn;
+  app.log.error = mockLogger.error;
+
+  await app.register(profileRoutes());
+  await app.ready();
+
+  return app;
+}
+
+// ===========================================================================
+// Test suite
+// ===========================================================================
+
+describe("profile routes", () => {
+  // =========================================================================
+  // GET /api/users/:handle
+  // =========================================================================
+
+  describe("GET /api/users/:handle", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns profile with activity summary", async () => {
+      // 1st select: user by handle
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()]);
+      // 2nd select: topic count
+      selectChain.where.mockResolvedValueOnce([{ count: 5 }]);
+      // 3rd select: reply count
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }]);
+      // 4th select: reactions on topics
+      selectChain.where.mockResolvedValueOnce([{ count: 3 }]);
+      // 5th select: reactions on replies
+      selectChain.where.mockResolvedValueOnce([{ count: 2 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/${TEST_HANDLE}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        did: string;
+        handle: string;
+        displayName: string;
+        role: string;
+        activity: {
+          topicCount: number;
+          replyCount: number;
+          reactionsReceived: number;
+        };
+      }>();
+      expect(body.did).toBe(TEST_DID);
+      expect(body.handle).toBe(TEST_HANDLE);
+      expect(body.displayName).toBe("Alice");
+      expect(body.role).toBe("user");
+      expect(body.activity.topicCount).toBe(5);
+      expect(body.activity.replyCount).toBe(10);
+      expect(body.activity.reactionsReceived).toBe(5);
+    });
+
+    it("returns 404 for unknown handle", async () => {
+      selectChain.where.mockResolvedValueOnce([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/nonexistent.bsky.social",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("serializes dates as ISO strings", async () => {
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/${TEST_HANDLE}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        firstSeenAt: string;
+        lastActiveAt: string;
+      }>();
+      expect(body.firstSeenAt).toBe(TEST_NOW);
+      expect(body.lastActiveAt).toBe(TEST_NOW);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/users/:handle/reputation
+  // =========================================================================
+
+  describe("GET /api/users/:handle/reputation", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns computed reputation (topics*5 + replies*2 + reactions*1)", async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()]);
+      // Topics: 3
+      selectChain.where.mockResolvedValueOnce([{ count: 3 }]);
+      // Replies: 7
+      selectChain.where.mockResolvedValueOnce([{ count: 7 }]);
+      // Reactions on topics: 4
+      selectChain.where.mockResolvedValueOnce([{ count: 4 }]);
+      // Reactions on replies: 6
+      selectChain.where.mockResolvedValueOnce([{ count: 6 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        did: string;
+        handle: string;
+        reputation: number;
+        breakdown: {
+          topicCount: number;
+          replyCount: number;
+          reactionsReceived: number;
+        };
+      }>();
+      expect(body.did).toBe(TEST_DID);
+      // reputation = (3 * 5) + (7 * 2) + (4 + 6) * 1 = 15 + 14 + 10 = 39
+      expect(body.reputation).toBe(39);
+      expect(body.breakdown.topicCount).toBe(3);
+      expect(body.breakdown.replyCount).toBe(7);
+      expect(body.breakdown.reactionsReceived).toBe(10);
+    });
+
+    it("returns 404 for unknown handle", async () => {
+      selectChain.where.mockResolvedValueOnce([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/nonexistent.bsky.social/reputation",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns zero reputation for user with no activity", async () => {
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{ reputation: number }>();
+      expect(body.reputation).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // POST /api/users/me/age-declaration
+  // =========================================================================
+
+  describe("POST /api/users/me/age-declaration", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("stores age declaration timestamp", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/users/me/age-declaration",
+        headers: { authorization: "Bearer test-token" },
+        payload: { confirm: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        success: boolean;
+        ageDeclarationAt: string;
+      }>();
+      expect(body.success).toBe(true);
+      expect(body.ageDeclarationAt).toBeTruthy();
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "POST",
+        url: "/api/users/me/age-declaration",
+        payload: { confirm: true },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+
+    it("returns 400 when confirm is not true", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/users/me/age-declaration",
+        headers: { authorization: "Bearer test-token" },
+        payload: { confirm: false },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when body is empty", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/users/me/age-declaration",
+        headers: { authorization: "Bearer test-token" },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/users/me/preferences
+  // =========================================================================
+
+  describe("GET /api/users/me/preferences", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns existing preferences", async () => {
+      selectChain.where.mockResolvedValueOnce([
+        samplePrefsRow({ maturityLevel: "mature", crossPostBluesky: true }),
+      ]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/preferences",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        maturityLevel: string;
+        crossPostBluesky: boolean;
+      }>();
+      expect(body.maturityLevel).toBe("mature");
+      expect(body.crossPostBluesky).toBe(true);
+    });
+
+    it("returns defaults when no preferences row exists", async () => {
+      selectChain.where.mockResolvedValueOnce([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/users/me/preferences",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        maturityLevel: string;
+        mutedWords: string[];
+        crossPostBluesky: boolean;
+        crossPostFrontpage: boolean;
+      }>();
+      expect(body.maturityLevel).toBe("sfw");
+      expect(body.mutedWords).toEqual([]);
+      expect(body.crossPostBluesky).toBe(false);
+      expect(body.crossPostFrontpage).toBe(false);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "GET",
+        url: "/api/users/me/preferences",
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+  });
+
+  // =========================================================================
+  // PUT /api/users/me/preferences
+  // =========================================================================
+
+  describe("PUT /api/users/me/preferences", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("upserts preferences and returns updated values", async () => {
+      // After upsert, the select returns updated prefs
+      selectChain.where.mockResolvedValueOnce([
+        samplePrefsRow({
+          maturityLevel: "mature",
+          mutedWords: ["spoiler"],
+        }),
+      ]);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/users/me/preferences",
+        headers: { authorization: "Bearer test-token" },
+        payload: {
+          maturityLevel: "mature",
+          mutedWords: ["spoiler"],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        maturityLevel: string;
+        mutedWords: string[];
+      }>();
+      expect(body.maturityLevel).toBe("mature");
+      expect(body.mutedWords).toEqual(["spoiler"]);
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "PUT",
+        url: "/api/users/me/preferences",
+        payload: { maturityLevel: "sfw" },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+
+    it("returns 400 for invalid maturityLevel", async () => {
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/users/me/preferences",
+        headers: { authorization: "Bearer test-token" },
+        payload: { maturityLevel: "invalid" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /api/users/me/communities/:communityId/preferences
+  // =========================================================================
+
+  describe("GET /api/users/me/communities/:communityId/preferences", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("returns existing community preferences", async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: "mature",
+          notificationPrefs: {
+            replies: true,
+            reactions: false,
+            mentions: true,
+            modActions: true,
+          },
+        }),
+      ]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        communityDid: string;
+        maturityOverride: string;
+        notificationPrefs: { replies: boolean };
+      }>();
+      expect(body.communityDid).toBe(COMMUNITY_DID);
+      expect(body.maturityOverride).toBe("mature");
+      expect(body.notificationPrefs.replies).toBe(true);
+    });
+
+    it("returns defaults when no row exists", async () => {
+      selectChain.where.mockResolvedValueOnce([]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        communityDid: string;
+        maturityOverride: null;
+        mutedWords: null;
+        notificationPrefs: null;
+      }>();
+      expect(body.communityDid).toBe(COMMUNITY_DID);
+      expect(body.maturityOverride).toBeNull();
+      expect(body.mutedWords).toBeNull();
+      expect(body.notificationPrefs).toBeNull();
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "GET",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+  });
+
+  // =========================================================================
+  // PUT /api/users/me/communities/:communityId/preferences
+  // =========================================================================
+
+  describe("PUT /api/users/me/communities/:communityId/preferences", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("upserts community preferences and returns updated values", async () => {
+      // After upsert, the select returns updated prefs
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: "sfw",
+          mutedWords: ["spam"],
+        }),
+      ]);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: "Bearer test-token" },
+        payload: {
+          maturityOverride: "sfw",
+          mutedWords: ["spam"],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json<{
+        communityDid: string;
+        maturityOverride: string;
+        mutedWords: string[];
+      }>();
+      expect(body.communityDid).toBe(COMMUNITY_DID);
+      expect(body.maturityOverride).toBe("sfw");
+      expect(body.mutedWords).toEqual(["spam"]);
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "PUT",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        payload: { maturityOverride: "sfw" },
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+
+    it("returns 400 for invalid maturityOverride", async () => {
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: "Bearer test-token" },
+        payload: { maturityOverride: "adult" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // DELETE /api/users/me
+  // =========================================================================
+
+  describe("DELETE /api/users/me", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser());
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetAllDbMocks();
+    });
+
+    it("deletes all data and returns 204", async () => {
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/users/me",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(response.statusCode).toBe(204);
+      // Transaction should be called once
+      expect(mockDb.transaction).toHaveBeenCalledOnce();
+      // Multiple delete calls within transaction (reactions, notifications x2,
+      // reports, replies, topics, community prefs, user prefs, users)
+      expect(mockDb.delete).toHaveBeenCalled();
+      // Check at least 8 delete calls (one per table)
+      expect(mockDb.delete.mock.calls.length).toBeGreaterThanOrEqual(8);
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      const noAuthApp = await buildTestApp(undefined);
+
+      const response = await noAuthApp.inject({
+        method: "DELETE",
+        url: "/api/users/me",
+      });
+
+      expect(response.statusCode).toBe(401);
+      await noAuthApp.close();
+    });
+
+    it("logs the GDPR purge with the user DID", async () => {
+      await app.inject({
+        method: "DELETE",
+        url: "/api/users/me",
+        headers: { authorization: "Bearer test-token" },
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { did: TEST_DID },
+        "GDPR Art. 17: all indexed data purged for user",
+      );
+    });
+  });
+});

--- a/tests/unit/validation/profiles.test.ts
+++ b/tests/unit/validation/profiles.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  userPreferencesSchema,
+  communityPreferencesSchema,
+  ageDeclarationSchema,
+} from "../../../src/validation/profiles.js";
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe("profile validation schemas", () => {
+  // =========================================================================
+  // userPreferencesSchema
+  // =========================================================================
+
+  describe("userPreferencesSchema", () => {
+    it("parses a fully populated valid body", () => {
+      const result = userPreferencesSchema.safeParse({
+        maturityLevel: "mature",
+        mutedWords: ["spoiler", "nsfw"],
+        blockedDids: ["did:plc:blocked1"],
+        mutedDids: ["did:plc:muted1"],
+        crossPostBluesky: true,
+        crossPostFrontpage: false,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityLevel).toBe("mature");
+        expect(result.data.mutedWords).toEqual(["spoiler", "nsfw"]);
+        expect(result.data.crossPostBluesky).toBe(true);
+      }
+    });
+
+    it("parses an empty body (all fields optional)", () => {
+      const result = userPreferencesSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityLevel).toBeUndefined();
+        expect(result.data.mutedWords).toBeUndefined();
+        expect(result.data.blockedDids).toBeUndefined();
+        expect(result.data.mutedDids).toBeUndefined();
+        expect(result.data.crossPostBluesky).toBeUndefined();
+        expect(result.data.crossPostFrontpage).toBeUndefined();
+      }
+    });
+
+    it("parses partial updates (only maturityLevel)", () => {
+      const result = userPreferencesSchema.safeParse({
+        maturityLevel: "sfw",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityLevel).toBe("sfw");
+      }
+    });
+
+    it("fails for invalid maturityLevel", () => {
+      const result = userPreferencesSchema.safeParse({
+        maturityLevel: "adult",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for empty strings in mutedWords", () => {
+      const result = userPreferencesSchema.safeParse({
+        mutedWords: [""],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for non-boolean crossPostBluesky", () => {
+      const result = userPreferencesSchema.safeParse({
+        crossPostBluesky: "yes",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts maturityLevel 'sfw'", () => {
+      const result = userPreferencesSchema.safeParse({
+        maturityLevel: "sfw",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts maturityLevel 'mature'", () => {
+      const result = userPreferencesSchema.safeParse({
+        maturityLevel: "mature",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // communityPreferencesSchema
+  // =========================================================================
+
+  describe("communityPreferencesSchema", () => {
+    it("parses a fully populated valid body", () => {
+      const result = communityPreferencesSchema.safeParse({
+        maturityOverride: "mature",
+        mutedWords: ["spoiler"],
+        blockedDids: ["did:plc:blocked1"],
+        mutedDids: ["did:plc:muted1"],
+        notificationPrefs: {
+          replies: true,
+          reactions: false,
+          mentions: true,
+          modActions: true,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityOverride).toBe("mature");
+        expect(result.data.notificationPrefs?.replies).toBe(true);
+        expect(result.data.notificationPrefs?.reactions).toBe(false);
+      }
+    });
+
+    it("parses an empty body (all fields optional)", () => {
+      const result = communityPreferencesSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityOverride).toBeUndefined();
+        expect(result.data.mutedWords).toBeUndefined();
+        expect(result.data.notificationPrefs).toBeUndefined();
+      }
+    });
+
+    it("accepts null values for nullable fields", () => {
+      const result = communityPreferencesSchema.safeParse({
+        maturityOverride: null,
+        mutedWords: null,
+        blockedDids: null,
+        mutedDids: null,
+        notificationPrefs: null,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.maturityOverride).toBeNull();
+        expect(result.data.mutedWords).toBeNull();
+        expect(result.data.notificationPrefs).toBeNull();
+      }
+    });
+
+    it("fails for invalid maturityOverride", () => {
+      const result = communityPreferencesSchema.safeParse({
+        maturityOverride: "adult",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for incomplete notificationPrefs", () => {
+      const result = communityPreferencesSchema.safeParse({
+        notificationPrefs: {
+          replies: true,
+          // missing other required fields
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails for non-boolean values in notificationPrefs", () => {
+      const result = communityPreferencesSchema.safeParse({
+        notificationPrefs: {
+          replies: "yes",
+          reactions: true,
+          mentions: true,
+          modActions: true,
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // ageDeclarationSchema
+  // =========================================================================
+
+  describe("ageDeclarationSchema", () => {
+    it("parses valid body with confirm: true", () => {
+      const result = ageDeclarationSchema.safeParse({ confirm: true });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.confirm).toBe(true);
+      }
+    });
+
+    it("fails when confirm is false", () => {
+      const result = ageDeclarationSchema.safeParse({ confirm: false });
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when confirm is missing", () => {
+      const result = ageDeclarationSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it("fails when confirm is a string", () => {
+      const result = ageDeclarationSchema.safeParse({ confirm: "true" });
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- User profile endpoints with activity summaries and reputation scoring
- Global and per-community user preferences (maturity levels, muted words, blocked DIDs, cross-posting toggles, notification prefs)
- Age declaration endpoint for content maturity gating
- GDPR Art. 17 account deletion with transactional purge across all tables

## Changes
- `src/db/schema/user-preferences.ts` - `user_preferences` and `user_community_preferences` tables
- `src/validation/profiles.ts` - Zod schemas for preferences, age declaration
- `src/routes/profiles.ts` - 8 endpoints (profile, reputation, preferences, deletion)
- `drizzle/0012_swift_tony_stark.sql` - Migration for new tables
- 56 new tests (763 total), all passing

## Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/users/:handle` | Optional | Profile with activity summary |
| GET | `/api/users/:handle/reputation` | No | Computed reputation score |
| POST | `/api/users/me/age-declaration` | Required | Age verification |
| GET | `/api/users/me/preferences` | Required | Get global preferences |
| PUT | `/api/users/me/preferences` | Required | Update global preferences |
| GET | `/api/users/me/communities/:id/preferences` | Required | Get community preferences |
| PUT | `/api/users/me/communities/:id/preferences` | Required | Update community preferences |
| DELETE | `/api/users/me` | Required | GDPR account deletion |

## Test plan
- [x] Schema tests for both new tables (13 tests)
- [x] Validation tests for all schemas (18 tests)
- [x] Route tests for all 8 endpoints (25 tests)
- [x] All 763 tests pass
- [x] Lint clean, typecheck clean