### PR TITLE
feat(api): add social cross-posting to Bluesky and Frontpage (M11)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     "./src/db/schema/reports.ts",
     "./src/db/schema/notifications.ts",
     "./src/db/schema/user-preferences.ts",
+    "./src/db/schema/cross-posts.ts",
   ],
   out: "./drizzle",
   dialect: "postgresql",

--- a/drizzle/0014_easy_the_leader.sql
+++ b/drizzle/0014_easy_the_leader.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "cross_posts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"topic_uri" text NOT NULL,
+	"service" text NOT NULL,
+	"cross_post_uri" text NOT NULL,
+	"cross_post_cid" text NOT NULL,
+	"author_did" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "cross_posts_topic_uri_idx" ON "cross_posts" USING btree ("topic_uri");--> statement-breakpoint
+CREATE INDEX "cross_posts_author_did_idx" ON "cross_posts" USING btree ("author_did");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1674 @@
+{
+  "id": "f1366e9b-ffb4-4ec1-b298-87c72085335b",
+  "prevId": "7300b203-dbcc-44da-87af-d96e41f832e3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_score": {
+          "name": "reputation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "age_declared_at": {
+          "name": "age_declared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturity_pref": {
+          "name": "maturity_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firehose_cursor": {
+      "name": "firehose_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_locked": {
+          "name": "is_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_mod_deleted": {
+          "name": "is_mod_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "topics_author_did_idx": {
+          "name": "topics_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_category_idx": {
+          "name": "topics_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_created_at_idx": {
+          "name": "topics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_last_activity_at_idx": {
+          "name": "topics_last_activity_at_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_community_did_idx": {
+          "name": "topics_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replies": {
+      "name": "replies",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cid": {
+          "name": "root_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_uri": {
+          "name": "parent_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_cid": {
+          "name": "parent_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "replies_author_did_idx": {
+          "name": "replies_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_root_uri_idx": {
+          "name": "replies_root_uri_idx",
+          "columns": [
+            {
+              "expression": "root_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_parent_uri_idx": {
+          "name": "replies_parent_uri_idx",
+          "columns": [
+            {
+              "expression": "parent_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_created_at_idx": {
+          "name": "replies_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "replies_community_did_idx": {
+          "name": "replies_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_cid": {
+          "name": "subject_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_author_did_idx": {
+          "name": "reactions_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_subject_uri_idx": {
+          "name": "reactions_subject_uri_idx",
+          "columns": [
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_community_did_idx": {
+          "name": "reactions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_author_subject_type_uniq": {
+          "name": "reactions_author_subject_type_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_did",
+            "subject_uri",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tracked_at": {
+          "name": "tracked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "initialized": {
+          "name": "initialized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_did": {
+          "name": "admin_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_name": {
+          "name": "community_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Barazo Community'"
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "reaction_set": {
+          "name": "reaction_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"like\"]'::jsonb"
+        },
+        "moderation_thresholds": {
+          "name": "moderation_thresholds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"autoBlockReportCount\":5,\"warnThreshold\":3}'::jsonb"
+        },
+        "word_filter": {
+          "name": "word_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "community_description": {
+          "name": "community_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_logo_url": {
+          "name": "community_logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_rating": {
+          "name": "maturity_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'safe'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_community_did_idx": {
+          "name": "categories_slug_community_did_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_parent_id_idx": {
+          "name": "categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_community_did_idx": {
+          "name": "categories_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_maturity_rating_idx": {
+          "name": "categories_maturity_rating_idx",
+          "columns": [
+            {
+              "expression": "maturity_rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_fk": {
+          "name": "categories_parent_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_actions": {
+      "name": "moderation_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_did": {
+          "name": "moderator_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_actions_moderator_did_idx": {
+          "name": "mod_actions_moderator_did_idx",
+          "columns": [
+            {
+              "expression": "moderator_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_community_did_idx": {
+          "name": "mod_actions_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_created_at_idx": {
+          "name": "mod_actions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_uri_idx": {
+          "name": "mod_actions_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mod_actions_target_did_idx": {
+          "name": "mod_actions_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_did": {
+          "name": "reporter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_did": {
+          "name": "target_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_type": {
+          "name": "reason_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolution_type": {
+          "name": "resolution_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reports_reporter_did_idx": {
+          "name": "reports_reporter_did_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_uri_idx": {
+          "name": "reports_target_uri_idx",
+          "columns": [
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_target_did_idx": {
+          "name": "reports_target_did_idx",
+          "columns": [
+            {
+              "expression": "target_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_community_did_idx": {
+          "name": "reports_community_did_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_status_idx": {
+          "name": "reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_unique_reporter_target_idx": {
+          "name": "reports_unique_reporter_target_idx",
+          "columns": [
+            {
+              "expression": "reporter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_did": {
+          "name": "recipient_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_did": {
+          "name": "actor_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_did_idx": {
+          "name": "notifications_recipient_did_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_read_idx": {
+          "name": "notifications_recipient_read_idx",
+          "columns": [
+            {
+              "expression": "recipient_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_community_preferences": {
+      "name": "user_community_preferences",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_did": {
+          "name": "community_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maturity_override": {
+          "name": "maturity_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_words": {
+          "name": "muted_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_dids": {
+          "name": "blocked_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_dids": {
+          "name": "muted_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_prefs": {
+          "name": "notification_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_community_prefs_did_idx": {
+          "name": "user_community_prefs_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_community_prefs_community_idx": {
+          "name": "user_community_prefs_community_idx",
+          "columns": [
+            {
+              "expression": "community_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_community_preferences_did_community_did_pk": {
+          "name": "user_community_preferences_did_community_did_pk",
+          "columns": [
+            "did",
+            "community_did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "maturity_level": {
+          "name": "maturity_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sfw'"
+        },
+        "age_declaration_at": {
+          "name": "age_declaration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muted_words": {
+          "name": "muted_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_dids": {
+          "name": "blocked_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "muted_dids": {
+          "name": "muted_dids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cross_post_bluesky": {
+          "name": "cross_post_bluesky",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cross_post_frontpage": {
+          "name": "cross_post_frontpage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_posts": {
+      "name": "cross_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_uri": {
+          "name": "topic_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cross_post_uri": {
+          "name": "cross_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cross_post_cid": {
+          "name": "cross_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cross_posts_topic_uri_idx": {
+          "name": "cross_posts_topic_uri_idx",
+          "columns": [
+            {
+              "expression": "topic_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cross_posts_author_did_idx": {
+          "name": "cross_posts_author_did_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1771039303672,
       "tag": "0013_rapid_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1771039690434,
+      "tag": "0014_easy_the_leader",
+      "breakpoints": true
     }
   ]
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -65,6 +65,17 @@ export const envSchema = z.object({
     .default("768")
     .transform((val) => Number(val))
     .pipe(z.number().int().min(384).max(1536)),
+
+  // Cross-posting
+  FEATURE_CROSSPOST_BLUESKY: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((v) => v === "true"),
+  FEATURE_CROSSPOST_FRONTPAGE: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
+  PUBLIC_URL: z.string().default("http://localhost:3001"),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/db/schema/cross-posts.ts
+++ b/src/db/schema/cross-posts.ts
@@ -1,0 +1,22 @@
+import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
+
+export const crossPosts = pgTable(
+  "cross_posts",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    topicUri: text("topic_uri").notNull(),
+    service: text("service", { enum: ["bluesky", "frontpage"] }).notNull(),
+    crossPostUri: text("cross_post_uri").notNull(),
+    crossPostCid: text("cross_post_cid").notNull(),
+    authorDid: text("author_did").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("cross_posts_topic_uri_idx").on(table.topicUri),
+    index("cross_posts_author_did_idx").on(table.authorDid),
+  ],
+);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -10,3 +10,4 @@ export { moderationActions } from "./moderation-actions.js";
 export { reports } from "./reports.js";
 export { notifications } from "./notifications.js";
 export { userPreferences, userCommunityPreferences } from "./user-preferences.js";
+export { crossPosts } from "./cross-posts.js";

--- a/src/services/cross-post.ts
+++ b/src/services/cross-post.ts
@@ -1,0 +1,267 @@
+import { eq } from "drizzle-orm";
+import type { PdsClient } from "../lib/pds-client.js";
+import type { Logger } from "../lib/logger.js";
+import type { Database } from "../db/index.js";
+import { crossPosts } from "../db/schema/cross-posts.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum grapheme length for Bluesky post text. */
+const BLUESKY_TEXT_LIMIT = 300;
+
+/** Maximum length for the Bluesky embed description. */
+const EMBED_DESCRIPTION_LIMIT = 300;
+
+/** AT Protocol collection for Bluesky posts. */
+const BLUESKY_COLLECTION = "app.bsky.feed.post";
+
+/** AT Protocol collection for Frontpage link submissions. */
+const FRONTPAGE_COLLECTION = "fyi.frontpage.post";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CrossPostParams {
+  did: string;
+  topicUri: string;
+  title: string;
+  content: string;
+  category: string;
+}
+
+export interface CrossPostService {
+  crossPostTopic(params: CrossPostParams): Promise<void>;
+  deleteCrossPosts(topicUri: string, did: string): Promise<void>;
+}
+
+export interface CrossPostConfig {
+  blueskyEnabled: boolean;
+  frontpageEnabled: boolean;
+  publicUrl: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the rkey from an AT URI.
+ * Format: at://did:plc:xxx/collection/rkey
+ */
+function extractRkey(uri: string): string {
+  const parts = uri.split("/");
+  return parts[parts.length - 1] ?? "";
+}
+
+/**
+ * Truncate text to a maximum number of characters, appending ellipsis if needed.
+ */
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength - 1) + "\u2026";
+}
+
+/**
+ * Build the Bluesky post text from topic title and content.
+ * Format: "{title}\n\n{truncated content}" (fitting within BLUESKY_TEXT_LIMIT).
+ */
+function buildBlueskyPostText(title: string, content: string): string {
+  const prefix = title + "\n\n";
+  const remainingChars = BLUESKY_TEXT_LIMIT - prefix.length;
+
+  if (remainingChars <= 0) {
+    return truncate(title, BLUESKY_TEXT_LIMIT);
+  }
+
+  return prefix + truncate(content, remainingChars);
+}
+
+/**
+ * Build the public URL for a topic from its AT URI.
+ */
+function buildTopicUrl(publicUrl: string, topicUri: string): string {
+  const rkey = extractRkey(topicUri);
+  return `${publicUrl}/topics/${rkey}`;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a cross-posting service that publishes topics to external platforms
+ * (Bluesky, Frontpage) via the user's PDS.
+ *
+ * Cross-posts are fire-and-forget: failures are logged but do not block
+ * topic creation. Each service is independent -- a failure in one does
+ * not prevent the other from succeeding.
+ */
+export function createCrossPostService(
+  pdsClient: PdsClient,
+  db: Database,
+  logger: Logger,
+  config: CrossPostConfig,
+): CrossPostService {
+  /**
+   * Cross-post a topic to Bluesky as an `app.bsky.feed.post` record
+   * with an `app.bsky.embed.external` embed containing a link back
+   * to the forum topic.
+   */
+  async function crossPostToBluesky(params: CrossPostParams): Promise<void> {
+    const topicUrl = buildTopicUrl(config.publicUrl, params.topicUri);
+    const postText = buildBlueskyPostText(params.title, params.content);
+
+    const record: Record<string, unknown> = {
+      $type: BLUESKY_COLLECTION,
+      text: postText,
+      createdAt: new Date().toISOString(),
+      embed: {
+        $type: "app.bsky.embed.external",
+        external: {
+          uri: topicUrl,
+          title: params.title,
+          description: truncate(params.content, EMBED_DESCRIPTION_LIMIT),
+        },
+      },
+      langs: ["en"],
+    };
+
+    const result = await pdsClient.createRecord(
+      params.did,
+      BLUESKY_COLLECTION,
+      record,
+    );
+
+    await db.insert(crossPosts).values({
+      topicUri: params.topicUri,
+      service: "bluesky",
+      crossPostUri: result.uri,
+      crossPostCid: result.cid,
+      authorDid: params.did,
+    });
+
+    logger.info(
+      { topicUri: params.topicUri, crossPostUri: result.uri },
+      "Cross-posted topic to Bluesky",
+    );
+  }
+
+  /**
+   * Cross-post a topic to Frontpage as an `fyi.frontpage.post` record
+   * (link submission pointing back to the forum topic).
+   */
+  async function crossPostToFrontpage(params: CrossPostParams): Promise<void> {
+    const topicUrl = buildTopicUrl(config.publicUrl, params.topicUri);
+
+    const record: Record<string, unknown> = {
+      title: params.title,
+      url: topicUrl,
+      createdAt: new Date().toISOString(),
+    };
+
+    const result = await pdsClient.createRecord(
+      params.did,
+      FRONTPAGE_COLLECTION,
+      record,
+    );
+
+    await db.insert(crossPosts).values({
+      topicUri: params.topicUri,
+      service: "frontpage",
+      crossPostUri: result.uri,
+      crossPostCid: result.cid,
+      authorDid: params.did,
+    });
+
+    logger.info(
+      { topicUri: params.topicUri, crossPostUri: result.uri },
+      "Cross-posted topic to Frontpage",
+    );
+  }
+
+  return {
+    async crossPostTopic(params: CrossPostParams): Promise<void> {
+      const tasks: Promise<PromiseSettledResult<void>>[] = [];
+
+      if (config.blueskyEnabled) {
+        tasks.push(
+          crossPostToBluesky(params)
+            .then<PromiseSettledResult<void>>(() => ({
+              status: "fulfilled" as const,
+              value: undefined,
+            }))
+            .catch<PromiseSettledResult<void>>((err: unknown) => {
+              logger.error(
+                { err, topicUri: params.topicUri, service: "bluesky" },
+                "Failed to cross-post to Bluesky",
+              );
+              return {
+                status: "rejected" as const,
+                reason: err,
+              };
+            }),
+        );
+      }
+
+      if (config.frontpageEnabled) {
+        tasks.push(
+          crossPostToFrontpage(params)
+            .then<PromiseSettledResult<void>>(() => ({
+              status: "fulfilled" as const,
+              value: undefined,
+            }))
+            .catch<PromiseSettledResult<void>>((err: unknown) => {
+              logger.error(
+                { err, topicUri: params.topicUri, service: "frontpage" },
+                "Failed to cross-post to Frontpage",
+              );
+              return {
+                status: "rejected" as const,
+                reason: err,
+              };
+            }),
+        );
+      }
+
+      await Promise.all(tasks);
+    },
+
+    async deleteCrossPosts(topicUri: string, did: string): Promise<void> {
+      const rows = await db
+        .select()
+        .from(crossPosts)
+        .where(eq(crossPosts.topicUri, topicUri));
+
+      for (const row of rows) {
+        const rkey = extractRkey(row.crossPostUri);
+        const collection =
+          row.service === "bluesky"
+            ? BLUESKY_COLLECTION
+            : FRONTPAGE_COLLECTION;
+
+        try {
+          await pdsClient.deleteRecord(did, collection, rkey);
+          logger.info(
+            { crossPostUri: row.crossPostUri, service: row.service },
+            "Deleted cross-post",
+          );
+        } catch (err: unknown) {
+          logger.warn(
+            { err, crossPostUri: row.crossPostUri, service: row.service },
+            "Failed to delete cross-post from PDS (best-effort)",
+          );
+        }
+      }
+
+      // Always clean up DB rows regardless of PDS delete success
+      await db
+        .delete(crossPosts)
+        .where(eq(crossPosts.topicUri, topicUri));
+    },
+  };
+}

--- a/tests/unit/db/schema/cross-posts.test.ts
+++ b/tests/unit/db/schema/cross-posts.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { crossPosts } from "../../../../src/db/schema/cross-posts.js";
+import { getTableName, getTableColumns } from "drizzle-orm";
+
+describe("cross-posts schema", () => {
+  it("should have the correct table name", () => {
+    expect(getTableName(crossPosts)).toBe("cross_posts");
+  });
+
+  it("should have all required columns", () => {
+    const columns = getTableColumns(crossPosts);
+    const columnNames = Object.keys(columns);
+
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("topicUri");
+    expect(columnNames).toContain("service");
+    expect(columnNames).toContain("crossPostUri");
+    expect(columnNames).toContain("crossPostCid");
+    expect(columnNames).toContain("authorDid");
+    expect(columnNames).toContain("createdAt");
+  });
+
+  it("should have id as primary key", () => {
+    const columns = getTableColumns(crossPosts);
+    expect(columns.id.primary).toBe(true);
+  });
+
+  it("should mark required columns as not null", () => {
+    const columns = getTableColumns(crossPosts);
+    expect(columns.topicUri.notNull).toBe(true);
+    expect(columns.service.notNull).toBe(true);
+    expect(columns.crossPostUri.notNull).toBe(true);
+    expect(columns.crossPostCid.notNull).toBe(true);
+    expect(columns.authorDid.notNull).toBe(true);
+    expect(columns.createdAt.notNull).toBe(true);
+  });
+
+  it("should have exactly 7 columns", () => {
+    const columns = getTableColumns(crossPosts);
+    expect(Object.keys(columns)).toHaveLength(7);
+  });
+
+  it("should have a default value for id", () => {
+    const columns = getTableColumns(crossPosts);
+    expect(columns.id.hasDefault).toBe(true);
+  });
+
+  it("should have a default value for createdAt", () => {
+    const columns = getTableColumns(crossPosts);
+    expect(columns.createdAt.hasDefault).toBe(true);
+  });
+});

--- a/tests/unit/routes/topics-replies-integration.test.ts
+++ b/tests/unit/routes/topics-replies-integration.test.ts
@@ -433,10 +433,10 @@ describe("topics + replies cross-endpoint integration", () => {
       // Transaction should have been used
       expect(mockDb.transaction).toHaveBeenCalledOnce();
 
-      // Inside the transaction, both replies and topic should be deleted
-      // The transaction mock calls fn(mockDb), so mockDb.delete should be called twice:
-      // once for replies (cascade) and once for the topic itself
-      expect(mockDb.delete).toHaveBeenCalledTimes(2);
+      // Inside the transaction, both replies and topic should be deleted.
+      // The transaction mock calls fn(mockDb), so mockDb.delete is called for:
+      //   1. replies (cascade), 2. topic itself, 3. cross-posts cleanup (fire-and-forget)
+      expect(mockDb.delete).toHaveBeenCalledTimes(3);
     });
 
     it("topic cascade delete uses rootUri to find related replies", async () => {
@@ -452,11 +452,11 @@ describe("topics + replies cross-endpoint integration", () => {
 
       expect(response.statusCode).toBe(204);
 
-      // Verify delete was called (replies first, then topic)
-      expect(mockDb.delete).toHaveBeenCalledTimes(2);
+      // Verify delete was called (replies, topic, and cross-posts cleanup)
+      expect(mockDb.delete).toHaveBeenCalledTimes(3);
 
-      // Both delete calls should have used .where()
-      expect(deleteChain.where).toHaveBeenCalledTimes(2);
+      // All delete calls should have used .where()
+      expect(deleteChain.where).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -717,8 +717,9 @@ describe("topics + replies cross-endpoint integration", () => {
       expect(deleteResponse.statusCode).toBe(204);
 
       // Should have cascade-deleted replies via transaction
+      // Delete count: 1. replies (cascade), 2. topic, 3. cross-posts cleanup
       expect(mockDb.transaction).toHaveBeenCalledOnce();
-      expect(mockDb.delete).toHaveBeenCalledTimes(2);
+      expect(mockDb.delete).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/tests/unit/services/cross-post.test.ts
+++ b/tests/unit/services/cross-post.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCrossPostService } from "../../../src/services/cross-post.js";
+import type { PdsClient, PdsWriteResult } from "../../../src/lib/pds-client.js";
+import { createMockDb, createChainableProxy } from "../../helpers/mock-db.js";
+import type { DbChain } from "../../helpers/mock-db.js";
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn().mockReturnThis(),
+  level: "info",
+  silent: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Mock PDS client
+// ---------------------------------------------------------------------------
+
+function createMockPdsClient(): PdsClient & {
+  createRecord: ReturnType<typeof vi.fn>;
+  updateRecord: ReturnType<typeof vi.fn>;
+  deleteRecord: ReturnType<typeof vi.fn>;
+} {
+  return {
+    createRecord: vi.fn<(did: string, collection: string, record: Record<string, unknown>) => Promise<PdsWriteResult>>(),
+    updateRecord: vi.fn<(did: string, collection: string, rkey: string, record: Record<string, unknown>) => Promise<PdsWriteResult>>(),
+    deleteRecord: vi.fn<(did: string, collection: string, rkey: string) => Promise<void>>(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test constants
+// ---------------------------------------------------------------------------
+
+const TEST_DID = "did:plc:testuser123";
+const TEST_TOPIC_URI = `at://${TEST_DID}/forum.barazo.topic.post/abc123`;
+const TEST_BLUESKY_URI = `at://${TEST_DID}/app.bsky.feed.post/bsky001`;
+const TEST_BLUESKY_CID = "bafyreibsky001";
+const TEST_FRONTPAGE_URI = `at://${TEST_DID}/fyi.frontpage.post/fp001`;
+const TEST_FRONTPAGE_CID = "bafyreifp001";
+const TEST_PUBLIC_URL = "https://forum.example.com";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cross-post service", () => {
+  let mockPds: ReturnType<typeof createMockPdsClient>;
+  let mockDb: ReturnType<typeof createMockDb>;
+  let insertChain: DbChain;
+  let selectChain: DbChain;
+  let deleteChain: DbChain;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPds = createMockPdsClient();
+    mockDb = createMockDb();
+    insertChain = createChainableProxy();
+    selectChain = createChainableProxy([]);
+    deleteChain = createChainableProxy();
+    mockDb.insert.mockReturnValue(insertChain);
+    mockDb.select.mockReturnValue(selectChain);
+    mockDb.delete.mockReturnValue(deleteChain);
+  });
+
+  // =========================================================================
+  // crossPostTopic
+  // =========================================================================
+
+  describe("crossPostTopic", () => {
+    it("cross-posts to Bluesky when enabled", async () => {
+      mockPds.createRecord.mockResolvedValue({
+        uri: TEST_BLUESKY_URI,
+        cid: TEST_BLUESKY_CID,
+      });
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "My Topic",
+        content: "Topic content here.",
+        category: "general",
+      });
+
+      expect(mockPds.createRecord).toHaveBeenCalledOnce();
+      const [did, collection, record] = mockPds.createRecord.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+      ];
+      expect(did).toBe(TEST_DID);
+      expect(collection).toBe("app.bsky.feed.post");
+      expect(record.$type).toBe("app.bsky.feed.post");
+      expect(record.text).toContain("My Topic");
+      expect((record.embed as Record<string, unknown>).$type).toBe(
+        "app.bsky.embed.external",
+      );
+
+      // Should insert cross-post record into DB
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topicUri: TEST_TOPIC_URI,
+          crossPostUri: TEST_BLUESKY_URI,
+        }) as Record<string, unknown>,
+        "Cross-posted topic to Bluesky",
+      );
+    });
+
+    it("cross-posts to Frontpage when enabled", async () => {
+      mockPds.createRecord.mockResolvedValue({
+        uri: TEST_FRONTPAGE_URI,
+        cid: TEST_FRONTPAGE_CID,
+      });
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: false,
+          frontpageEnabled: true,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "Frontpage Topic",
+        content: "Content for Frontpage.",
+        category: "general",
+      });
+
+      expect(mockPds.createRecord).toHaveBeenCalledOnce();
+      const [did, collection, record] = mockPds.createRecord.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+      ];
+      expect(did).toBe(TEST_DID);
+      expect(collection).toBe("fyi.frontpage.post");
+      expect(record.title).toBe("Frontpage Topic");
+      expect(record.url).toBe(`${TEST_PUBLIC_URL}/topics/abc123`);
+
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+    });
+
+    it("cross-posts to both Bluesky and Frontpage concurrently when both enabled", async () => {
+      mockPds.createRecord
+        .mockResolvedValueOnce({
+          uri: TEST_BLUESKY_URI,
+          cid: TEST_BLUESKY_CID,
+        })
+        .mockResolvedValueOnce({
+          uri: TEST_FRONTPAGE_URI,
+          cid: TEST_FRONTPAGE_CID,
+        });
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: true,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "Dual Post",
+        content: "Content for both.",
+        category: "general",
+      });
+
+      // Both services called
+      expect(mockPds.createRecord).toHaveBeenCalledTimes(2);
+      // Both DB inserts
+      expect(mockDb.insert).toHaveBeenCalledTimes(2);
+      // Both logged
+      expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    });
+
+    it("does nothing when both services are disabled", async () => {
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: false,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "No Cross-Post",
+        content: "Should not go anywhere.",
+        category: "general",
+      });
+
+      expect(mockPds.createRecord).not.toHaveBeenCalled();
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("logs error but does not throw when Bluesky fails", async () => {
+      mockPds.createRecord.mockRejectedValue(
+        new Error("Bluesky PDS unreachable"),
+      );
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      // Should NOT throw
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "Will Fail",
+        content: "Bluesky is down.",
+        category: "general",
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topicUri: TEST_TOPIC_URI,
+          service: "bluesky",
+        }) as Record<string, unknown>,
+        "Failed to cross-post to Bluesky",
+      );
+      // DB insert should NOT be called since PDS failed
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("continues Frontpage when Bluesky fails", async () => {
+      mockPds.createRecord
+        .mockRejectedValueOnce(new Error("Bluesky PDS error"))
+        .mockResolvedValueOnce({
+          uri: TEST_FRONTPAGE_URI,
+          cid: TEST_FRONTPAGE_CID,
+        });
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: true,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "Partial Success",
+        content: "One succeeds, one fails.",
+        category: "general",
+      });
+
+      // Bluesky error logged
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ service: "bluesky" }) as Record<string, unknown>,
+        "Failed to cross-post to Bluesky",
+      );
+
+      // Frontpage success logged
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          crossPostUri: TEST_FRONTPAGE_URI,
+        }) as Record<string, unknown>,
+        "Cross-posted topic to Frontpage",
+      );
+
+      // Only the Frontpage cross-post stored in DB
+      expect(mockDb.insert).toHaveBeenCalledOnce();
+    });
+
+    it("builds correct Bluesky post text with title and truncated content", async () => {
+      mockPds.createRecord.mockResolvedValue({
+        uri: TEST_BLUESKY_URI,
+        cid: TEST_BLUESKY_CID,
+      });
+
+      const longContent = "A".repeat(500);
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "Short Title",
+        content: longContent,
+        category: "general",
+      });
+
+      const [, , record] = mockPds.createRecord.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+      ];
+      const postText = record.text as string;
+      // Post text should not exceed 300 chars
+      expect(postText.length).toBeLessThanOrEqual(300);
+      expect(postText).toContain("Short Title");
+    });
+
+    it("builds correct topic URL from AT URI", async () => {
+      mockPds.createRecord.mockResolvedValue({
+        uri: TEST_BLUESKY_URI,
+        cid: TEST_BLUESKY_CID,
+      });
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.crossPostTopic({
+        did: TEST_DID,
+        topicUri: TEST_TOPIC_URI,
+        title: "URL Test",
+        content: "Content.",
+        category: "general",
+      });
+
+      const [, , record] = mockPds.createRecord.mock.calls[0] as [
+        string,
+        string,
+        Record<string, unknown>,
+      ];
+      const embed = record.embed as Record<string, unknown>;
+      const external = embed.external as Record<string, unknown>;
+      expect(external.uri).toBe(`${TEST_PUBLIC_URL}/topics/abc123`);
+    });
+  });
+
+  // =========================================================================
+  // deleteCrossPosts
+  // =========================================================================
+
+  describe("deleteCrossPosts", () => {
+    it("deletes all cross-posts for a topic from PDS and DB", async () => {
+      selectChain.where.mockResolvedValueOnce([
+        {
+          id: "cp-1",
+          topicUri: TEST_TOPIC_URI,
+          service: "bluesky",
+          crossPostUri: TEST_BLUESKY_URI,
+          crossPostCid: TEST_BLUESKY_CID,
+          authorDid: TEST_DID,
+          createdAt: new Date(),
+        },
+        {
+          id: "cp-2",
+          topicUri: TEST_TOPIC_URI,
+          service: "frontpage",
+          crossPostUri: TEST_FRONTPAGE_URI,
+          crossPostCid: TEST_FRONTPAGE_CID,
+          authorDid: TEST_DID,
+          createdAt: new Date(),
+        },
+      ]);
+
+      mockPds.deleteRecord.mockResolvedValue(undefined);
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: true,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.deleteCrossPosts(TEST_TOPIC_URI, TEST_DID);
+
+      // Should delete both records from PDS
+      expect(mockPds.deleteRecord).toHaveBeenCalledTimes(2);
+      expect(mockPds.deleteRecord).toHaveBeenCalledWith(
+        TEST_DID,
+        "app.bsky.feed.post",
+        "bsky001",
+      );
+      expect(mockPds.deleteRecord).toHaveBeenCalledWith(
+        TEST_DID,
+        "fyi.frontpage.post",
+        "fp001",
+      );
+
+      // Should delete DB rows
+      expect(mockDb.delete).toHaveBeenCalledOnce();
+      expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    });
+
+    it("cleans up DB rows even when PDS delete fails", async () => {
+      selectChain.where.mockResolvedValueOnce([
+        {
+          id: "cp-1",
+          topicUri: TEST_TOPIC_URI,
+          service: "bluesky",
+          crossPostUri: TEST_BLUESKY_URI,
+          crossPostCid: TEST_BLUESKY_CID,
+          authorDid: TEST_DID,
+          createdAt: new Date(),
+        },
+      ]);
+
+      mockPds.deleteRecord.mockRejectedValue(
+        new Error("PDS delete failed"),
+      );
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: false,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      // Should NOT throw
+      await service.deleteCrossPosts(TEST_TOPIC_URI, TEST_DID);
+
+      // Warning logged for PDS failure
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          crossPostUri: TEST_BLUESKY_URI,
+          service: "bluesky",
+        }) as Record<string, unknown>,
+        "Failed to delete cross-post from PDS (best-effort)",
+      );
+
+      // DB rows still deleted
+      expect(mockDb.delete).toHaveBeenCalledOnce();
+    });
+
+    it("does nothing when no cross-posts exist for the topic", async () => {
+      selectChain.where.mockResolvedValueOnce([]);
+
+      const service = createCrossPostService(
+        mockPds,
+        mockDb as never,
+        mockLogger as never,
+        {
+          blueskyEnabled: true,
+          frontpageEnabled: true,
+          publicUrl: TEST_PUBLIC_URL,
+        },
+      );
+
+      await service.deleteCrossPosts(TEST_TOPIC_URI, TEST_DID);
+
+      expect(mockPds.deleteRecord).not.toHaveBeenCalled();
+      // DB delete still called (no-op if no rows match)
+      expect(mockDb.delete).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fire-and-forget cross-posting after topic creation to Bluesky and Frontpage
- Bluesky posts with `app.bsky.embed.external` link cards (enabled by default)
- Frontpage link submissions behind `FEATURE_CROSSPOST_FRONTPAGE` flag
- Best-effort cross-post deletion when topics are deleted
- Independent per-service error handling

## HUMAN CHECKPOINT
**Requires manual verification:** Bluesky post rendering with link cards cannot be tested automatically. After deploying to staging with a Bluesky test account, verify:
- [ ] Link card renders correctly on bsky.app (title, description)
- [ ] Post text is properly truncated within 300 char limit
- [ ] Frontpage submission works when flag enabled

## Changes
- `src/db/schema/cross-posts.ts` - New table for cross-post AT URI tracking
- `src/services/cross-post.ts` - Cross-posting service (create + delete)
- `src/config/env.ts` - Feature flags + PUBLIC_URL env var
- `src/routes/topics.ts` - Integrated cross-posting into POST/DELETE handlers
- `drizzle/0014_easy_the_leader.sql` - Migration for cross_posts table
- 17 new tests (790 total), all passing

## New Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| `FEATURE_CROSSPOST_BLUESKY` | `true` | Enable Bluesky cross-posting |
| `FEATURE_CROSSPOST_FRONTPAGE` | `false` | Enable Frontpage cross-posting |
| `PUBLIC_URL` | `http://localhost:3001` | Base URL for link card embeds |

## Test plan
- [x] Bluesky cross-post creates correct record format
- [x] Frontpage cross-post creates correct record format
- [x] Both services run independently (one failure doesn't block other)
- [x] Disabled services are skipped
- [x] Cross-post deletion handles PDS failures gracefully
- [x] Post text truncated to 300 characters
- [x] All 790 tests pass
- [x] Lint clean, typecheck clean