### PR TITLE
feat(auth): resolve handle from DID via AT Protocol identity layer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,6 +36,8 @@ import { createRequireAdmin } from "./auth/require-admin.js";
 import { createSetupService } from "./setup/service.js";
 import type { SetupService } from "./setup/service.js";
 import { createPlcDidService } from "./services/plc-did.js";
+import { createHandleResolver } from "./lib/handle-resolver.js";
+import type { HandleResolver } from "./lib/handle-resolver.js";
 import type { Database } from "./db/index.js";
 import type { Cache } from "./cache/index.js";
 
@@ -50,6 +52,7 @@ declare module "fastify" {
     sessionService: SessionService;
     authMiddleware: AuthMiddleware;
     setupService: SetupService;
+    handleResolver: HandleResolver;
     requireAdmin: ReturnType<typeof createRequireAdmin>;
   }
 }
@@ -142,6 +145,10 @@ export async function buildApp(env: Env) {
   app.decorateRequest("user", undefined as RequestUser | undefined);
   const authMiddleware = createAuthMiddleware(sessionService, app.log);
   app.decorate("authMiddleware", authMiddleware);
+
+  // Handle resolver (DID -> handle, with cache)
+  const handleResolver = createHandleResolver(cache, db, app.log);
+  app.decorate("handleResolver", handleResolver);
 
   // PLC DID service + Setup service
   const plcDidService = createPlcDidService(app.log);

--- a/src/lib/handle-resolver.ts
+++ b/src/lib/handle-resolver.ts
@@ -1,0 +1,172 @@
+import type { Cache } from "../cache/index.js";
+import type { Database } from "../db/index.js";
+import type { Logger } from "./logger.js";
+import { users } from "../db/schema/users.js";
+import { eq } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HANDLE_CACHE_PREFIX = "barazo:handle:";
+const HANDLE_CACHE_TTL = 3600; // 1 hour
+const PLC_DIRECTORY_URL = "https://plc.directory";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** DID document from PLC directory. */
+interface PlcDidDocument {
+  id: string;
+  alsoKnownAs?: string[];
+}
+
+export interface HandleResolver {
+  /**
+   * Resolve a DID to its AT Protocol handle.
+   *
+   * Resolution order:
+   * 1. Valkey cache (1-hour TTL)
+   * 2. Users table in PostgreSQL (populated by firehose)
+   * 3. PLC directory (for did:plc:*) -- fetches the DID document
+   *
+   * Returns the DID itself as fallback if resolution fails (never blocks auth).
+   */
+  resolve(did: string): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract handle from a DID document's alsoKnownAs field.
+ * AT Protocol handles appear as "at://{handle}" entries.
+ */
+function extractHandleFromDidDocument(doc: PlcDidDocument): string | undefined {
+  if (!doc.alsoKnownAs || !Array.isArray(doc.alsoKnownAs)) {
+    return undefined;
+  }
+
+  for (const aka of doc.alsoKnownAs) {
+    if (typeof aka === "string" && aka.startsWith("at://")) {
+      return aka.slice("at://".length);
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createHandleResolver(
+  cache: Cache,
+  db: Database,
+  logger: Logger,
+): HandleResolver {
+  async function resolveFromCache(did: string): Promise<string | undefined> {
+    const cached = await cache.get(`${HANDLE_CACHE_PREFIX}${did}`);
+    if (cached !== null) {
+      return cached;
+    }
+    return undefined;
+  }
+
+  async function resolveFromDb(did: string): Promise<string | undefined> {
+    const rows = await db
+      .select({ handle: users.handle })
+      .from(users)
+      .where(eq(users.did, did))
+      .limit(1);
+
+    const row = rows[0];
+    if (row !== undefined && row.handle !== did) {
+      return row.handle;
+    }
+    return undefined;
+  }
+
+  async function resolveFromPlcDirectory(did: string): Promise<string | undefined> {
+    if (!did.startsWith("did:plc:")) {
+      // did:web resolution is not yet needed for MVP
+      logger.debug({ did }, "Non-PLC DID, skipping PLC directory lookup");
+      return undefined;
+    }
+
+    const url = `${PLC_DIRECTORY_URL}/${encodeURIComponent(did)}`;
+
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { did, status: response.status },
+        "PLC directory lookup failed",
+      );
+      return undefined;
+    }
+
+    const doc = (await response.json()) as PlcDidDocument;
+    return extractHandleFromDidDocument(doc);
+  }
+
+  async function cacheHandle(did: string, handle: string): Promise<void> {
+    await cache.set(
+      `${HANDLE_CACHE_PREFIX}${did}`,
+      handle,
+      "EX",
+      HANDLE_CACHE_TTL,
+    );
+  }
+
+  async function resolve(did: string): Promise<string> {
+    // 1. Check Valkey cache
+    try {
+      const cached = await resolveFromCache(did);
+      if (cached) {
+        return cached;
+      }
+    } catch (err: unknown) {
+      logger.warn({ err, did }, "Handle cache lookup failed, continuing");
+    }
+
+    // 2. Check users table (firehose may have indexed the handle)
+    try {
+      const dbHandle = await resolveFromDb(did);
+      if (dbHandle) {
+        // Populate cache for next time
+        await cacheHandle(did, dbHandle).catch((err: unknown) => {
+          logger.warn({ err, did }, "Failed to cache handle from DB");
+        });
+        return dbHandle;
+      }
+    } catch (err: unknown) {
+      logger.warn({ err, did }, "Handle DB lookup failed, continuing");
+    }
+
+    // 3. Resolve from PLC directory
+    try {
+      const plcHandle = await resolveFromPlcDirectory(did);
+      if (plcHandle) {
+        // Populate cache for next time
+        await cacheHandle(did, plcHandle).catch((err: unknown) => {
+          logger.warn({ err, did }, "Failed to cache handle from PLC");
+        });
+        return plcHandle;
+      }
+    } catch (err: unknown) {
+      logger.warn({ err, did }, "PLC directory lookup failed, continuing");
+    }
+
+    // 4. Fallback: return DID itself (auth should never fail due to handle resolution)
+    logger.info({ did }, "Handle resolution failed, using DID as fallback");
+    return did;
+  }
+
+  return { resolve };
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -44,7 +44,7 @@ export function authRoutes(
   oauthClient: NodeOAuthClient,
 ): FastifyPluginCallback {
   return (app, _opts, done) => {
-    const { sessionService, env } = app;
+    const { sessionService, handleResolver, env } = app;
     const dev = isDevMode(env.OAUTH_CLIENT_ID);
     const sessionTtl = env.OAUTH_SESSION_TTL;
 
@@ -95,10 +95,9 @@ export function authRoutes(
         // Extract DID from the OAuth session
         const did = result.session.did;
 
-        // TODO(M3): Resolve handle from DID via AT Protocol identity layer.
-        // Currently uses DID as placeholder. Will be resolved when identity
-        // resolver is wired up (user profile caching from AT Protocol identity).
-        const handle = did;
+        // Resolve handle from DID via AT Protocol identity layer
+        // (PLC directory lookup with Valkey cache + DB fallback)
+        const handle = await handleResolver.resolve(did);
 
         const session = await sessionService.createSession(did, handle);
 

--- a/tests/unit/lib/handle-resolver.test.ts
+++ b/tests/unit/lib/handle-resolver.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHandleResolver } from "../../../src/lib/handle-resolver.js";
+import type { Cache } from "../../../src/cache/index.js";
+import type { Database } from "../../../src/db/index.js";
+import type { Logger } from "../../../src/lib/logger.js";
+
+// ---------------------------------------------------------------------------
+// Mock functions
+// ---------------------------------------------------------------------------
+
+const cacheGetFn = vi.fn<(...args: unknown[]) => Promise<string | null>>();
+const cacheSetFn = vi.fn<(...args: unknown[]) => Promise<string>>();
+
+const mockCache = {
+  get: cacheGetFn,
+  set: cacheSetFn,
+} as unknown as Cache;
+
+const dbSelectFn = vi.fn();
+const mockDb = {
+  select: dbSelectFn,
+} as unknown as Database;
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_DID = "did:plc:test123456789";
+const TEST_HANDLE = "alice.bsky.social";
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("handle-resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("returns handle from Valkey cache when available", async () => {
+    cacheGetFn.mockResolvedValueOnce(TEST_HANDLE);
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_HANDLE);
+    expect(cacheGetFn).toHaveBeenCalledWith(`barazo:handle:${TEST_DID}`);
+    expect(dbSelectFn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to DB when cache misses", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // Mock the Drizzle chain: db.select().from().where().limit()
+    const limitFn = vi.fn().mockResolvedValueOnce([{ handle: TEST_HANDLE }]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_HANDLE);
+    // Should cache the result
+    expect(cacheSetFn).toHaveBeenCalledWith(
+      `barazo:handle:${TEST_DID}`,
+      TEST_HANDLE,
+      "EX",
+      3600,
+    );
+  });
+
+  it("skips DB result when handle equals DID (not yet resolved)", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // DB has DID as handle (placeholder from before handle resolution)
+    const limitFn = vi.fn().mockResolvedValueOnce([{ handle: TEST_DID }]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    // Mock PLC directory fetch
+    const plcDoc = {
+      id: TEST_DID,
+      alsoKnownAs: [`at://${TEST_HANDLE}`],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(plcDoc), { status: 200 }),
+    );
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_HANDLE);
+  });
+
+  it("falls back to PLC directory when cache and DB miss", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // DB returns no results
+    const limitFn = vi.fn().mockResolvedValueOnce([]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    // Mock PLC directory fetch
+    const plcDoc = {
+      id: TEST_DID,
+      alsoKnownAs: [`at://${TEST_HANDLE}`],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(plcDoc), { status: 200 }),
+    );
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_HANDLE);
+    // Should cache the result
+    expect(cacheSetFn).toHaveBeenCalledWith(
+      `barazo:handle:${TEST_DID}`,
+      TEST_HANDLE,
+      "EX",
+      3600,
+    );
+  });
+
+  it("returns DID as fallback when all resolution methods fail", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // DB returns no results
+    const limitFn = vi.fn().mockResolvedValueOnce([]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    // PLC directory returns 404
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Not found", { status: 404 }),
+    );
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_DID);
+  });
+
+  it("handles PLC directory network errors gracefully", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // DB returns no results
+    const limitFn = vi.fn().mockResolvedValueOnce([]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    // PLC directory fetch throws
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    // Falls back to DID
+    expect(handle).toBe(TEST_DID);
+  });
+
+  it("skips PLC lookup for did:web DIDs", async () => {
+    const webDid = "did:web:example.com";
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    // DB returns no results
+    const limitFn = vi.fn().mockResolvedValueOnce([]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(webDid);
+
+    // Should not call PLC directory for did:web
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Falls back to DID
+    expect(handle).toBe(webDid);
+  });
+
+  it("handles cache errors gracefully and continues resolution", async () => {
+    cacheGetFn.mockRejectedValueOnce(new Error("Valkey down"));
+
+    // DB has the handle
+    const limitFn = vi.fn().mockResolvedValueOnce([{ handle: TEST_HANDLE }]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_HANDLE);
+  });
+
+  it("handles missing alsoKnownAs in PLC document", async () => {
+    cacheGetFn.mockResolvedValueOnce(null);
+
+    const limitFn = vi.fn().mockResolvedValueOnce([]);
+    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    dbSelectFn.mockReturnValue({ from: fromFn });
+
+    // PLC document without alsoKnownAs
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: TEST_DID }), { status: 200 }),
+    );
+
+    const resolver = createHandleResolver(mockCache, mockDb, mockLogger);
+    const handle = await resolver.resolve(TEST_DID);
+
+    expect(handle).toBe(TEST_DID);
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve AT Protocol handles from DIDs during OAuth callback instead of using DID as placeholder
- Three-tier resolution: Valkey cache (1h TTL) -> PostgreSQL users table -> PLC directory lookup
- Graceful fallback to DID if all resolution methods fail (auth never blocks)

## Changes
- `src/lib/handle-resolver.ts` -- new HandleResolver service with cache/DB/PLC resolution
- `src/app.ts` -- wire HandleResolver into Fastify instance
- `src/routes/auth.ts` -- use HandleResolver in OAuth callback (replaces TODO)
- `tests/unit/lib/handle-resolver.test.ts` -- 9 tests covering all resolution paths
- `tests/unit/routes/auth.test.ts` -- updated callback tests for resolved handles

## Context
Closes API M3 gap identified in strategic-review-2026-02.md P2.5 checkpoint. PRD checklist (`specs/prd-api.md` M3) and implementation plan updated.

## Test plan
- [x] CI passes (lint, typecheck, build, tests)
- [x] 988 tests pass (including 9 new handle-resolver tests)
- [x] All existing auth route tests updated and passing