### PR TITLE
ci(staging): add deploy trigger on push to main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,13 +5,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   trigger-deploy:
     name: Trigger Staging Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch to barazo-deploy
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.DEPLOY_PAT }}
           repository: barazo-forum/barazo-deploy


### PR DESCRIPTION
## Summary

- Add `deploy-staging.yml` workflow that fires `repository_dispatch` to `barazo-deploy` on push to `main`
- Passes exact commit SHA so staging builds the correct API version

## Dependencies

- Requires `DEPLOY_PAT` org secret (GitHub PAT with `repo` scope for cross-repo dispatch)
- Requires barazo-forum/barazo-deploy#21 merged first (the deploy workflow that receives the dispatch)

## Test plan

- [ ] Merge barazo-deploy PR first
- [ ] Set up `DEPLOY_PAT` org secret
- [ ] Push to main, verify `repository_dispatch` triggers deploy workflow in barazo-deploy