### PR TITLE
fix(docker): use pnpm deploy for catalog-compatible prod install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,15 +43,9 @@ COPY barazo-api/ ./barazo-api/
 RUN pnpm --filter @barazo-forum/lexicons build && \
     pnpm --filter barazo-api build
 
-# Create standalone production deployment:
-# Pack lexicons as tarball, then install API prod deps with npm
-RUN cd /workspace/barazo-lexicons && pnpm pack --pack-destination /tmp && \
-    mkdir -p /app/deploy && \
-    cp /workspace/barazo-api/package.json /app/deploy/ && \
-    cd /app/deploy && \
-    npm install --omit=dev --install-links \
-      $(ls /tmp/barazo-forum-lexicons-*.tgz) && \
-    rm -rf /root/.npm
+# Create standalone production deployment with resolved dependencies.
+# pnpm deploy resolves catalog: entries and copies only prod deps.
+RUN pnpm --filter barazo-api deploy /app/deploy --prod
 
 # ---------------------------------------------------------------------------
 # Stage 3: Production runner


### PR DESCRIPTION
## Summary

- Replace `npm install` with `pnpm deploy` in the Dockerfile's builder stage
- `npm install` can't resolve `catalog:` entries in package.json (from #35)
- `pnpm deploy` handles catalog resolution natively and creates a standalone prod deployment

## Changes

- `Dockerfile`: Replaced the multi-step `pnpm pack` + `npm install` approach with a single `pnpm deploy --prod` command

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Staging deploy succeeds after merge