### PR TITLE
fix(docker): add --legacy flag for pnpm deploy in v10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN pnpm --filter @barazo-forum/lexicons build && \
 
 # Create standalone production deployment with resolved dependencies.
 # pnpm deploy resolves catalog: entries and copies only prod deps.
-RUN pnpm --filter barazo-api deploy /app/deploy --prod
+RUN pnpm --filter barazo-api deploy /app/deploy --prod --legacy
 
 # ---------------------------------------------------------------------------
 # Stage 3: Production runner


### PR DESCRIPTION
## Summary

- pnpm v10 requires `--legacy` flag for `pnpm deploy` when workspace doesn't use injected deps
- Follows up from #41 which switched from npm install to pnpm deploy

## Test plan

- [ ] CI passes
- [ ] Staging deploy succeeds after merge