### PR TITLE
fix(docker): use inject-workspace-packages instead of legacy deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR /workspace
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.29.2 --activate
 
-# Copy workspace root config
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Copy workspace root config (including .npmrc for inject-workspace-packages)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
 # Copy all workspace package.json files (needed for pnpm install)
 COPY barazo-lexicons/package.json ./barazo-lexicons/
@@ -44,8 +44,8 @@ RUN pnpm --filter @barazo-forum/lexicons build && \
     pnpm --filter barazo-api build
 
 # Create standalone production deployment with resolved dependencies.
-# pnpm deploy resolves catalog: entries and copies only prod deps.
-RUN pnpm --filter barazo-api deploy /app/deploy --prod --legacy
+# pnpm deploy copies workspace + prod deps (requires inject-workspace-packages=true in .npmrc).
+RUN pnpm --filter barazo-api deploy /app/deploy --prod
 
 # ---------------------------------------------------------------------------
 # Stage 3: Production runner


### PR DESCRIPTION
## Summary
- Adds `.npmrc` to the `COPY` line in the deps stage so `inject-workspace-packages=true` is available
- Removes `--legacy` flag from `pnpm deploy` (deprecated in pnpm v10)
- Updates comments to reflect the new approach

## Context
pnpm v10 replaced the `--legacy` flag on `pnpm deploy` with `inject-workspace-packages=true` in `.npmrc`. Without this change, Docker builds fail with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`.

**Coordinated with:** barazo-forum/barazo-workspace (adds the .npmrc setting) and barazo-forum/barazo-deploy (copies .npmrc in CI).

## Test plan
- [ ] Merge barazo-workspace PR first, then barazo-deploy, then this one
- [ ] Verify Docker build succeeds: `docker build -f barazo-api/Dockerfile .`
- [ ] Verify the built container starts and passes health check