### PR TITLE
fix(security): add explicit rate limit config to public GET endpoints

### DIFF
--- a/src/routes/replies.ts
+++ b/src/routes/replies.ts
@@ -448,6 +448,7 @@ export function replyRoutes(): FastifyPluginCallback {
     // -------------------------------------------------------------------
 
     app.get("/api/topics/:topicUri/replies", {
+      config: { rateLimit: { max: env.RATE_LIMIT_READ_ANON, timeWindow: "1 minute" } },
       preHandler: [authMiddleware.optionalAuth],
       schema: {
         tags: ["Replies"],

--- a/src/routes/topics.ts
+++ b/src/routes/topics.ts
@@ -461,6 +461,7 @@ export function topicRoutes(): FastifyPluginCallback {
     // -------------------------------------------------------------------
 
     app.get("/api/topics", {
+      config: { rateLimit: { max: env.RATE_LIMIT_READ_ANON, timeWindow: "1 minute" } },
       preHandler: [authMiddleware.optionalAuth],
       schema: {
         tags: ["Topics"],


### PR DESCRIPTION
## Summary

- Adds explicit `config.rateLimit` to `GET /api/topics` and `GET /api/topics/:topicUri/replies`
- Resolves 2 of 4 CodeQL "missing rate limiting" alerts (js/missing-rate-limiting)
- The remaining 2 alerts on auth routes are false positives (already have per-route rate limit config that CodeQL can't detect)

## Context

The global `@fastify/rate-limit` plugin already covers all routes at 100 req/min. These explicit per-route configs make the rate limiting visible to static analysis tools and codify the intent directly on the route definitions.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 1397 tests pass
- [x] CI passes