### PR TITLE
feat(sybil): graph-based sybil resistance and reputation hardening

### DIFF
--- a/tests/unit/routes/replies.test.ts
+++ b/tests/unit/routes/replies.test.ts
@@ -894,7 +894,7 @@ describe('reply routes', () => {
           mutedDids: [],
         },
       ])
-       
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- thenable mock for Drizzle chain
       selectChain.where.mockImplementationOnce(() => selectChain) // 6: replies .where
 
       const rows = [

--- a/tests/unit/routes/topics.test.ts
+++ b/tests/unit/routes/topics.test.ts
@@ -843,7 +843,7 @@ describe('topic routes', () => {
       //   - Call 7 returns the author user row
 
       selectChain.where.mockResolvedValueOnce([]) // 4: loadBlockMuteLists
-       
+
       selectChain.where.mockImplementationOnce(() => selectChain) // 5: topics .where
       selectChain.where.mockResolvedValueOnce([]) // 6: loadMutedWords global
       selectChain.where.mockResolvedValueOnce([


### PR DESCRIPTION
## Summary

Implements P2.10: Sybil Resistance + Reputation Hardening, addressing VUL-010 (HIGH severity). Adds all 5 defense layers from `decisions/architecture.md`:

- **EigenTrust algorithm** -- graph-based trust propagation from admin-managed trust seeds with double-buffered iteration and convergence detection (alpha=0.5, max 20 iterations, threshold 0.001)
- **Sybil cluster detection** -- BFS connected components on low-trust DIDs (trust < 0.05), flags clusters with internal/external ratio > 0.8
- **Interaction graph** -- records reply, reaction, and co-participation edges (fire-and-forget from route handlers, co-participation capped at 50 authors)
- **Behavioral heuristics** -- burst voting detection, trigram Jaccard content similarity, interaction diversity scoring (all Drizzle ORM, no raw SQL)
- **Reputation formula integration** -- `base * voterTrustScore * pdsTrustFactor * clusterDiversityFactor` wired into profiles endpoint

### New files (25)

- 7 database schemas: `interaction_graph`, `trust_seeds`, `trust_scores`, `sybil_clusters`, `sybil_cluster_members`, `behavioral_flags`, `pds_trust_factors`
- 5 services: `trust-graph.ts`, `sybil-detector.ts`, `interaction-graph.ts`, `cluster-diversity.ts`, `behavioral-heuristics.ts`
- 1 background job: `compute-trust-graph.ts` (EigenTrust -> heuristics -> detection)
- 1 route file: `admin-sybil.ts` (trust seeds, clusters, PDS trust, behavioral flags, recompute)
- 1 validation file: `sybil.ts` (Zod schemas)
- 13 test files: 127 new tests including sybil attack simulation

### Modified files (10)

- `app.ts` -- service registration + route mounting
- `profiles.ts` -- weighted reputation formula
- `replies.ts`, `reactions.ts` -- fire-and-forget interaction recording
- `schema/index.ts` -- new table exports
- `mock-db.ts` -- leftJoin, groupBy, having support
- 4 existing test files -- trust score mocking for compatibility

### Key design decisions

- **Sentinel pattern** for communityId: `.notNull().default("")` instead of nullable, avoiding PostgreSQL NULL != NULL in composite PKs
- **Fire-and-forget** interaction recording: route handlers don't await graph updates
- **suspicionRatio** computed at serialization time, not stored (avoids stale data)

### Verification

- 1545/1545 tests pass
- 0 lint errors, 0 type errors
- Sybil simulation: 20 real accounts retain high trust, 10 sybil accounts earn near-zero trust
- Sonnet code review: 3 Critical + 6 High findings all resolved

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] Sybil simulation test verifies trust separation (`pnpm test -- --grep "sybil"`)
- [ ] Deploy fresh installation to staging and verify new tables are created