### PR TITLE
chore(deps): upgrade eslint to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^25.2.3",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.31.9",
-    "eslint": "^9.39.2",
+    "eslint": "^10.0.0",
     "husky": "catalog:",
     "lint-staged": "catalog:",
     "prettier": "catalog:",
@@ -68,7 +68,7 @@
     "testcontainers": "^11.11.0",
     "tsx": "^4.20.3",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.55.0",
+    "typescript-eslint": "^8.56.0",
     "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade eslint from `^9.39.2` to `^10.0.0` to resolve the minimatch ReDoS vulnerability (GHSA-3ppc-4f35-3m26) in the `eslint > minimatch@^3.1.2` chain. eslint 10 uses `minimatch@^10.1.1` which is patched.
- Bump `typescript-eslint` from `^8.55.0` to `^8.56.0` (adds eslint 10 peer dependency support).

The remaining 2 minimatch paths (`testcontainers > archiver > archiver-utils > glob > minimatch@^9` and `testcontainers > archiver > readdir-glob > minimatch@^5`) are dev-only and awaiting upstream fixes in archiver/readdir-glob.

## Test plan
- [ ] CI Lint step passes with eslint 10
- [ ] CI Security Scan: verify minimatch path count reduced
- [ ] No new lint errors introduced