### PR TITLE
fix(deps): override minimatch to patch ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
     "vitest": "^4.0.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "minimatch": ">=10.2.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `pnpm.overrides` to force `minimatch@>=10.2.1` across all transitive dependencies
- Fixes [GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26): ReDoS via repeated wildcards with non-matching literal in pattern
- All `minimatch` versions `<10.2.1` are vulnerable with no backported fix in 9.x or 5.x

**Affected dependency paths:**
- `@typescript-eslint/typescript-estree > minimatch@9.0.5` (devDep)
- `testcontainers > archiver > readdir-glob > minimatch@5.1.6` (devDep)
- `testcontainers > archiver > archiver-utils > glob > minimatch@9.0.5` (devDep)
- `@atproto/tap > ... > @ts-morph/common > minimatch@10.2.0` (prod, one patch behind)
- `@sentry/node > minimatch@9.0.5` (prod)

## Test plan
- [x] All 1628 unit tests pass locally with the override
- [x] TypeScript typecheck clean
- [x] CI passes (lint, typecheck, tests, security scan)