### PR TITLE
ci(codeql): exclude Fastify rate-limit false positive

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+# CodeQL configuration for barazo-api
+# Uses the extended query suite with exclusions for false positives.
+
+name: 'Barazo API CodeQL Config'
+
+# Exclude queries that produce false positives with Fastify.
+# js/missing-rate-limiting does not recognise @fastify/rate-limit's
+# per-route config.rateLimit option and flags every handler as unprotected.
+query-filters:
+  - exclude:
+      id: js/missing-rate-limiting

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Switch CodeQL from default setup to advanced setup with a custom config
- Exclude `js/missing-rate-limiting` rule which does not recognise `@fastify/rate-limit`'s per-route `config.rateLimit` pattern
- All flagged routes already have rate limiting configured (alerts #18, #19, #20, #21 were dismissed as false positives)
- Keeps the `security-extended` query suite for all other rules

## Why

The `js/missing-rate-limiting` CodeQL rule is designed for Express middleware patterns and doesn't understand Fastify's per-route rate limit config. Every route handler gets flagged despite having `config: { rateLimit: { max: N, timeWindow: '1 minute' } }` set. These alerts recur on every code change.

## After merge

Disable the CodeQL default setup in repo settings (Settings > Code security > Code scanning) since the workflow file takes over.

## Test plan

- [ ] Verify CodeQL workflow runs on this PR
- [ ] Confirm no `js/missing-rate-limiting` alerts are produced
- [ ] Disable default setup after merge