### PR TITLE
feat(auth): verify DID documents on authenticated requests

### DIFF
--- a/src/lib/did-document-verifier.ts
+++ b/src/lib/did-document-verifier.ts
@@ -1,0 +1,148 @@
+import type { Cache } from '../cache/index.js'
+import type { Logger } from './logger.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DID_DOC_CACHE_PREFIX = 'barazo:did-doc:'
+/** Soft TTL in seconds -- triggers background refresh after this. */
+export const DID_DOC_SOFT_TTL = 3600 // 1 hour
+/** Hard TTL in seconds -- Valkey key expiry. */
+export const DID_DOC_HARD_TTL = 7200 // 2 hours
+
+const PLC_DIRECTORY_URL = 'https://plc.directory'
+const PLC_FETCH_TIMEOUT = 5000 // 5 seconds
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DidVerificationResult = { active: true } | { active: false; reason: string }
+
+interface CachedDidEntry {
+  active: boolean
+  reason?: string
+  resolvedAt: number
+}
+
+export interface DidDocumentVerifier {
+  /** Verify that a DID is still active. */
+  verify(did: string): Promise<DidVerificationResult>
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createDidDocumentVerifier(cache: Cache, logger: Logger): DidDocumentVerifier {
+  /**
+   * Resolve a DID document from PLC directory and return whether it's active.
+   */
+  async function resolveFromPlc(did: string): Promise<DidVerificationResult> {
+    const url = `${PLC_DIRECTORY_URL}/${did}`
+
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(PLC_FETCH_TIMEOUT),
+    })
+
+    if (response.ok) {
+      return { active: true }
+    }
+
+    if (response.status === 410) {
+      return { active: false, reason: 'DID has been tombstoned' }
+    }
+
+    if (response.status === 404) {
+      return { active: false, reason: 'DID not found in PLC directory' }
+    }
+
+    // Unexpected status -- treat as resolution failure
+    logger.warn({ did, status: response.status }, 'Unexpected PLC directory response')
+    throw new Error(`PLC directory returned ${String(response.status)}`)
+  }
+
+  /**
+   * Cache a verification result with hard TTL.
+   */
+  async function cacheResult(did: string, result: DidVerificationResult): Promise<void> {
+    const entry: CachedDidEntry = {
+      active: result.active,
+      resolvedAt: Date.now(),
+      ...(!result.active && { reason: (result as { reason: string }).reason }),
+    }
+
+    await cache.set(`${DID_DOC_CACHE_PREFIX}${did}`, JSON.stringify(entry), 'EX', DID_DOC_HARD_TTL)
+  }
+
+  /**
+   * Trigger a non-blocking background refresh for a DID.
+   */
+  function backgroundRefresh(did: string): void {
+    resolveFromPlc(did)
+      .then(async (result) => {
+        await cacheResult(did, result)
+        logger.debug({ did }, 'Background DID document refresh completed')
+      })
+      .catch((err: unknown) => {
+        logger.warn({ err, did }, 'Background DID document refresh failed')
+      })
+  }
+
+  async function verify(did: string): Promise<DidVerificationResult> {
+    // did:web -- skip PLC verification (PLC only handles did:plc)
+    if (!did.startsWith('did:plc:')) {
+      return { active: true }
+    }
+
+    // 1. Try cache
+    let cachedEntry: CachedDidEntry | undefined
+    try {
+      const raw = await cache.get(`${DID_DOC_CACHE_PREFIX}${did}`)
+      if (raw !== null) {
+        cachedEntry = JSON.parse(raw) as CachedDidEntry
+
+        const age = Date.now() - cachedEntry.resolvedAt
+        const isPastSoftTtl = age > DID_DOC_SOFT_TTL * 1000
+
+        if (!isPastSoftTtl) {
+          // Fresh cache hit -- return immediately
+          if (cachedEntry.active) {
+            return { active: true }
+          }
+          return { active: false, reason: cachedEntry.reason ?? 'DID is not active' }
+        }
+
+        // Past soft TTL -- serve stale and trigger background refresh
+        backgroundRefresh(did)
+
+        if (cachedEntry.active) {
+          return { active: true }
+        }
+        return { active: false, reason: cachedEntry.reason ?? 'DID is not active' }
+      }
+    } catch (err: unknown) {
+      logger.warn({ err, did }, 'DID document cache read failed')
+      // Fall through to PLC directory resolution
+    }
+
+    // 2. Cache miss -- resolve from PLC directory
+    try {
+      const result = await resolveFromPlc(did)
+
+      // Cache the result (fire-and-forget on failure)
+      cacheResult(did, result).catch((err: unknown) => {
+        logger.warn({ err, did }, 'Failed to cache DID verification result')
+      })
+
+      return result
+    } catch (err: unknown) {
+      logger.error({ err, did }, 'DID document resolution failed')
+      return { active: false, reason: 'DID document resolution failed' }
+    }
+  }
+
+  return { verify }
+}

--- a/tests/unit/lib/did-document-verifier.test.ts
+++ b/tests/unit/lib/did-document-verifier.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  createDidDocumentVerifier,
+  DID_DOC_CACHE_PREFIX,
+  DID_DOC_HARD_TTL,
+  DID_DOC_SOFT_TTL,
+} from '../../../src/lib/did-document-verifier.js'
+import type { DidDocumentVerifier } from '../../../src/lib/did-document-verifier.js'
+import type { Logger } from '../../../src/lib/logger.js'
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+function createMockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    silent: vi.fn(),
+    level: 'silent',
+  } as unknown as Logger
+}
+
+// ---------------------------------------------------------------------------
+// Mock cache
+// ---------------------------------------------------------------------------
+
+function createMockCache() {
+  return {
+    get: vi.fn<(...args: unknown[]) => Promise<string | null>>(),
+    set: vi.fn<(...args: unknown[]) => Promise<string>>(),
+  }
+}
+
+type MockCache = ReturnType<typeof createMockCache>
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_DID = 'did:plc:abc123def456'
+const TEST_DID_WEB = 'did:web:example.com'
+
+function activeDidDoc() {
+  return {
+    id: TEST_DID,
+    alsoKnownAs: ['at://alice.bsky.social'],
+    verificationMethods: { atproto: 'did:key:z123' },
+    rotationKeys: ['did:key:z456'],
+    services: {
+      atproto_pds: { type: 'AtprotoPersonalDataServer', endpoint: 'https://pds.example.com' },
+    },
+  }
+}
+
+function cachedEntry(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    active: true,
+    resolvedAt: Date.now() - 30 * 60 * 1000, // 30 min ago (within soft TTL)
+    ...overrides,
+  })
+}
+
+function staleCachedEntry() {
+  return JSON.stringify({
+    active: true,
+    resolvedAt: Date.now() - 70 * 60 * 1000, // 70 min ago (past soft TTL)
+  })
+}
+
+function deactivatedCachedEntry() {
+  return JSON.stringify({
+    active: false,
+    reason: 'tombstoned',
+    resolvedAt: Date.now() - 10 * 60 * 1000,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DidDocumentVerifier', () => {
+  let verifier: DidDocumentVerifier
+  let mockCache: MockCache
+  let mockLogger: Logger
+  let originalFetch: typeof globalThis.fetch
+  let mockFetch: ReturnType<typeof vi.fn<typeof globalThis.fetch>>
+
+  beforeEach(() => {
+    mockCache = createMockCache()
+    mockLogger = createMockLogger()
+    verifier = createDidDocumentVerifier(mockCache as never, mockLogger)
+
+    originalFetch = globalThis.fetch
+    mockFetch = vi.fn<typeof globalThis.fetch>()
+    globalThis.fetch = mockFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  // =========================================================================
+  // Cache hit - active DID
+  // =========================================================================
+
+  describe('cache hit with active DID', () => {
+    it('returns active result without calling PLC directory', async () => {
+      mockCache.get.mockResolvedValueOnce(cachedEntry())
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: true })
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(mockCache.get).toHaveBeenCalledWith(`${DID_DOC_CACHE_PREFIX}${TEST_DID}`)
+    })
+  })
+
+  // =========================================================================
+  // Cache hit - deactivated DID
+  // =========================================================================
+
+  describe('cache hit with deactivated DID', () => {
+    it('returns inactive result', async () => {
+      mockCache.get.mockResolvedValueOnce(deactivatedCachedEntry())
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: false, reason: 'tombstoned' })
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  // =========================================================================
+  // Cache miss - successful PLC resolution
+  // =========================================================================
+
+  describe('cache miss with successful PLC resolution', () => {
+    it('resolves from PLC directory and caches the result', async () => {
+      mockCache.get.mockResolvedValueOnce(null) // cache miss
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(activeDidDoc()), { status: 200 }))
+      mockCache.set.mockResolvedValueOnce('OK')
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: true })
+
+      // Verify PLC directory was called
+      expect(mockFetch).toHaveBeenCalledOnce()
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
+      expect(url).toBe(`https://plc.directory/${TEST_DID}`)
+
+      // Verify cache was populated with hard TTL
+      expect(mockCache.set).toHaveBeenCalledWith(
+        `${DID_DOC_CACHE_PREFIX}${TEST_DID}`,
+        expect.any(String) as string,
+        'EX',
+        DID_DOC_HARD_TTL
+      )
+    })
+  })
+
+  // =========================================================================
+  // Cache miss - tombstoned DID (410)
+  // =========================================================================
+
+  describe('cache miss with tombstoned DID', () => {
+    it('rejects with tombstoned reason and caches the result', async () => {
+      mockCache.get.mockResolvedValueOnce(null)
+      mockFetch.mockResolvedValueOnce(new Response('Gone', { status: 410 }))
+      mockCache.set.mockResolvedValueOnce('OK')
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: false, reason: 'DID has been tombstoned' })
+
+      // Cache the tombstoned status to avoid repeated lookups
+      expect(mockCache.set).toHaveBeenCalledOnce()
+    })
+  })
+
+  // =========================================================================
+  // Cache miss - DID not found (404)
+  // =========================================================================
+
+  describe('cache miss with DID not found', () => {
+    it('rejects with not-found reason', async () => {
+      mockCache.get.mockResolvedValueOnce(null)
+      mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: false, reason: 'DID not found in PLC directory' })
+    })
+  })
+
+  // =========================================================================
+  // Resolution failure - no cache (fail closed)
+  // =========================================================================
+
+  describe('resolution failure with no cache', () => {
+    it('rejects when PLC directory is unreachable and no cache exists', async () => {
+      mockCache.get.mockResolvedValueOnce(null)
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({
+        active: false,
+        reason: 'DID document resolution failed',
+      })
+    })
+  })
+
+  // =========================================================================
+  // Resolution failure - stale cache available (serve stale)
+  // =========================================================================
+
+  describe('resolution failure with stale cache available', () => {
+    it('uses stale cached value when PLC directory fails', async () => {
+      // First call: cache returns stale entry (past soft TTL but before hard TTL)
+      // The verifier should try to refresh, fail, then serve stale
+      mockCache.get.mockResolvedValueOnce(staleCachedEntry())
+      // Background refresh will fail
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await verifier.verify(TEST_DID)
+
+      // Should still return active from stale cache
+      expect(result).toStrictEqual({ active: true })
+    })
+  })
+
+  // =========================================================================
+  // Cache error - fallback to PLC directory
+  // =========================================================================
+
+  describe('cache error', () => {
+    it('falls back to PLC directory when cache read fails', async () => {
+      mockCache.get.mockRejectedValueOnce(new Error('Valkey down'))
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(activeDidDoc()), { status: 200 }))
+      mockCache.set.mockRejectedValueOnce(new Error('Valkey down')) // cache write also fails
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: true })
+      expect(mockFetch).toHaveBeenCalledOnce()
+    })
+
+    it('rejects when both cache and PLC directory fail', async () => {
+      mockCache.get.mockRejectedValueOnce(new Error('Valkey down'))
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({
+        active: false,
+        reason: 'DID document resolution failed',
+      })
+    })
+  })
+
+  // =========================================================================
+  // did:web passthrough
+  // =========================================================================
+
+  describe('did:web handling', () => {
+    it('allows did:web DIDs without PLC lookup', async () => {
+      const result = await verifier.verify(TEST_DID_WEB)
+
+      expect(result).toStrictEqual({ active: true })
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(mockCache.get).not.toHaveBeenCalled()
+    })
+  })
+
+  // =========================================================================
+  // Background refresh on soft TTL expiry
+  // =========================================================================
+
+  describe('background refresh', () => {
+    it('triggers background refresh when cached entry is past soft TTL', async () => {
+      mockCache.get.mockResolvedValueOnce(staleCachedEntry())
+      // Background refresh succeeds
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(activeDidDoc()), { status: 200 }))
+      mockCache.set.mockResolvedValueOnce('OK')
+
+      const result = await verifier.verify(TEST_DID)
+
+      // Returns immediately from stale cache
+      expect(result).toStrictEqual({ active: true })
+
+      // Wait for background refresh to complete
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledOnce()
+      })
+    })
+
+    it('does not trigger background refresh when cached entry is within soft TTL', async () => {
+      mockCache.get.mockResolvedValueOnce(cachedEntry())
+
+      const result = await verifier.verify(TEST_DID)
+
+      expect(result).toStrictEqual({ active: true })
+
+      // No fetch should have been triggered
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  // =========================================================================
+  // Constants exported correctly
+  // =========================================================================
+
+  describe('exported constants', () => {
+    it('has 1-hour soft TTL', () => {
+      expect(DID_DOC_SOFT_TTL).toBe(3600)
+    })
+
+    it('has 2-hour hard TTL', () => {
+      expect(DID_DOC_HARD_TTL).toBe(7200)
+    })
+
+    it('has correct cache prefix', () => {
+      expect(DID_DOC_CACHE_PREFIX).toBe('barazo:did-doc:')
+    })
+  })
+})

--- a/tests/unit/routes/setup.test.ts
+++ b/tests/unit/routes/setup.test.ts
@@ -73,8 +73,10 @@ describe('setup routes', () => {
       silent: vi.fn(),
       level: 'silent',
     }
+    const mockDidVerifier = { verify: vi.fn().mockResolvedValue({ active: true }) }
     const authMiddleware: AuthMiddleware = createAuthMiddleware(
       mockSessionService,
+      mockDidVerifier,
       mockLogger as never
     )
 


### PR DESCRIPTION
## Summary
- Add DID document verification to the auth middleware so deactivated/tombstoned DIDs are rejected instead of being trusted for the full 7-day session lifetime
- New `DidDocumentVerifier` service resolves `did:plc` via PLC directory with Valkey cache (1h soft / 2h hard TTL, stale-while-revalidate pattern)
- Closes the security gap described in the TODO at middleware.ts:59-62

## Changes
- **`src/lib/did-document-verifier.ts`** (new) -- DID document verifier service with PLC directory resolution, Valkey caching, SWR background refresh, fail-closed semantics
- **`src/auth/middleware.ts`** -- `createAuthMiddleware` now accepts `DidDocumentVerifier`; `requireAuth` rejects inactive DIDs (401 for deactivated, 502 for resolution failure); `optionalAuth` continues unauthenticated on DID failure; TODO comment removed
- **`src/app.ts`** -- Creates and injects `DidDocumentVerifier` into the auth middleware
- **`tests/unit/lib/did-document-verifier.test.ts`** (new) -- 15 tests: active DID, deactivated DID, tombstoned (410), cache hit/miss, resolution failure with/without stale cache, did:web passthrough, background refresh, cache errors
- **`tests/unit/auth/middleware.test.ts`** -- Updated to 15 tests with DID verification: active DID passes, deactivated rejects (401), resolution failure (502), verifier throw (502), optionalAuth degradation
- **`tests/unit/routes/setup.test.ts`** -- Passes mock DID verifier to updated `createAuthMiddleware` signature

## Test plan
- [x] All 1660 tests pass (102 test files)
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Pre-commit hooks pass (lint-staged + prettier)
- [ ] CI passes (lint, typecheck, build, tests)