### PR TITLE
test(coverage): improve branch coverage from 75% to 87%

### DIFF
--- a/tests/unit/routes/notifications.test.ts
+++ b/tests/unit/routes/notifications.test.ts
@@ -131,6 +131,37 @@ async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
   return app
 }
 
+/**
+ * Build a test app with a pass-through auth middleware that does NOT set
+ * request.user and does NOT send a 401. This simulates the defensive guard
+ * inside handler bodies where `if (!user)` is checked.
+ */
+async function buildTestAppWithPassthroughAuth(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false })
+
+  const passthroughAuth: AuthMiddleware = {
+    requireAuth: async (_request, _reply) => {
+      // Intentionally do nothing -- neither set user nor abort
+    },
+    optionalAuth: (_request, _reply) => Promise.resolve(),
+  }
+
+  app.decorate('db', mockDb as never)
+  app.decorate('env', mockEnv)
+  app.decorate('authMiddleware', passthroughAuth)
+  app.decorate('firehose', {} as never)
+  app.decorate('oauthClient', {} as never)
+  app.decorate('sessionService', {} as SessionService)
+  app.decorate('setupService', {} as SetupService)
+  app.decorate('cache', {} as never)
+  app.decorateRequest('user', undefined as RequestUser | undefined)
+
+  await app.register(notificationRoutes())
+  await app.ready()
+
+  return app
+}
+
 // ===========================================================================
 // Test suite
 // ===========================================================================
@@ -379,6 +410,504 @@ describe('notification routes', () => {
 
       expect(response.statusCode).toBe(400)
     })
+
+    it('filters to unread only when unreadOnly=true', async () => {
+      const unreadRow = sampleNotificationRow({ id: 1, read: false })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([unreadRow])
+      selectChain.where.mockResolvedValueOnce([{ count: 1 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?unreadOnly=true',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number; read: boolean }>
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(1)
+      expect(body.notifications[0]?.read).toBe(false)
+    })
+
+    it('returns all notifications when unreadOnly is not set', async () => {
+      const unreadRow = sampleNotificationRow({ id: 1, read: false })
+      const readRow = sampleNotificationRow({ id: 2, read: true })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([unreadRow, readRow])
+      selectChain.where.mockResolvedValueOnce([{ count: 2 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number; read: boolean }>
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(2)
+      expect(body.total).toBe(2)
+    })
+
+    it('returns all notifications when unreadOnly=false', async () => {
+      const unreadRow = sampleNotificationRow({ id: 1, read: false })
+      const readRow = sampleNotificationRow({ id: 2, read: true })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([unreadRow, readRow])
+      selectChain.where.mockResolvedValueOnce([{ count: 2 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?unreadOnly=false',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number; read: boolean }>
+        total: number
+      }>()
+      // unreadOnly transforms 'false' string -> val === 'true' -> false, so no unreadOnly filter
+      expect(body.notifications).toHaveLength(2)
+    })
+
+    it('applies cursor-based pagination with a valid cursor', async () => {
+      const cursorData = JSON.stringify({
+        createdAt: '2026-02-14T11:00:00.000Z',
+        id: 5,
+      })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const row = sampleNotificationRow({
+        id: 6,
+        createdAt: new Date('2026-02-14T11:30:00.000Z'),
+      })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([row])
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number }>
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(1)
+      expect(body.notifications[0]?.id).toBe(6)
+      expect(body.total).toBe(10)
+    })
+
+    it('applies cursor with createdAt equal to "unread"', async () => {
+      const cursorData = JSON.stringify({
+        createdAt: 'unread',
+        id: 3,
+      })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const row = sampleNotificationRow({ id: 4 })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([row])
+      selectChain.where.mockResolvedValueOnce([{ count: 5 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number }>
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(1)
+      expect(body.notifications[0]?.id).toBe(4)
+    })
+
+    it('ignores invalid cursor (malformed base64)', async () => {
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?cursor=not-valid-base64!!!',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toEqual([])
+      expect(body.cursor).toBeNull()
+    })
+
+    it('ignores cursor with invalid structure (missing id)', async () => {
+      const cursorData = JSON.stringify({ createdAt: '2026-02-14T11:00:00.000Z' })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+      }>()
+      expect(body.notifications).toEqual([])
+      expect(body.cursor).toBeNull()
+    })
+
+    it('ignores cursor with invalid structure (missing createdAt)', async () => {
+      const cursorData = JSON.stringify({ id: 5 })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+      }>()
+      expect(body.notifications).toEqual([])
+      expect(body.cursor).toBeNull()
+    })
+
+    it('ignores cursor with wrong types (id is string instead of number)', async () => {
+      const cursorData = JSON.stringify({ createdAt: '2026-02-14T11:00:00.000Z', id: 'abc' })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+      }>()
+      expect(body.notifications).toEqual([])
+      expect(body.cursor).toBeNull()
+    })
+
+    it('defaults total to 0 when count result is empty', async () => {
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      // Return empty array for count query (no rows)
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.total).toBe(0)
+    })
+
+    it('defaults total to 0 when count result row has undefined count', async () => {
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([])
+      // Return row with undefined count
+      selectChain.where.mockResolvedValueOnce([{ count: undefined }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.total).toBe(0)
+    })
+
+    it('uses default limit of 25 when limit is not specified', async () => {
+      // Return exactly 25 rows (less than 26 = limit + 1), so no cursor
+      const rows = Array.from({ length: 25 }, (_, i) =>
+        sampleNotificationRow({
+          id: i + 1,
+          createdAt: new Date(
+            `2026-02-14T${String(12).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}:00.000Z`
+          ),
+        })
+      )
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce(rows)
+      selectChain.where.mockResolvedValueOnce([{ count: 25 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(25)
+      expect(body.cursor).toBeNull()
+    })
+
+    it('applies custom limit from query parameter', async () => {
+      const rows = Array.from({ length: 5 }, (_, i) =>
+        sampleNotificationRow({
+          id: i + 1,
+          createdAt: new Date(`2026-02-14T12:${String(i).padStart(2, '0')}:00.000Z`),
+        })
+      )
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce(rows)
+      selectChain.where.mockResolvedValueOnce([{ count: 5 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?limit=5',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(5)
+      expect(body.cursor).toBeNull()
+    })
+
+    it('combines unreadOnly and cursor parameters', async () => {
+      const cursorData = JSON.stringify({
+        createdAt: '2026-02-14T11:00:00.000Z',
+        id: 3,
+      })
+      const cursor = Buffer.from(cursorData).toString('base64')
+
+      const row = sampleNotificationRow({ id: 4, read: false })
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce([row])
+      selectChain.where.mockResolvedValueOnce([{ count: 5 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/notifications?unreadOnly=true&cursor=${cursor}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: Array<{ id: number; read: boolean }>
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(1)
+      expect(body.notifications[0]?.read).toBe(false)
+    })
+
+    it('returns 400 for negative limit (-1)', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?limit=-1',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns max limit of 100', async () => {
+      const rows = Array.from({ length: 100 }, (_, i) =>
+        sampleNotificationRow({
+          id: i + 1,
+          createdAt: new Date(`2026-02-14T12:00:${String(i % 60).padStart(2, '0')}.000Z`),
+        })
+      )
+      const chainableThenable = {
+        ...selectChain,
+        then: (resolve: (val: unknown) => void, reject?: (err: unknown) => void) =>
+          Promise.resolve([]).then(resolve, reject),
+        orderBy: selectChain.orderBy,
+        limit: selectChain.limit,
+        returning: selectChain.returning,
+      }
+      selectChain.where.mockReturnValueOnce(chainableThenable)
+      selectChain.limit.mockResolvedValueOnce(rows)
+      selectChain.where.mockResolvedValueOnce([{ count: 100 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications?limit=100',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notifications: unknown[]
+        cursor: string | null
+        total: number
+      }>()
+      expect(body.notifications).toHaveLength(100)
+      expect(body.cursor).toBeNull()
+    })
   })
 
   // =========================================================================
@@ -452,6 +981,90 @@ describe('notification routes', () => {
       expect(response.statusCode).toBe(401)
       await noAuthApp.close()
     })
+
+    it('prioritizes all over notificationId when both provided', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: 42, all: true },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ success: boolean }>()
+      expect(body.success).toBe(true)
+      // The all=true branch is taken, so update is called once (for all)
+      expect(mockDb.update).toHaveBeenCalledOnce()
+    })
+
+    it('returns 400 when all is false and notificationId is not provided', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { all: false },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for invalid body (notificationId is negative)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: -1 },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for invalid body (notificationId is not an integer)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: 1.5 },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for invalid body (notificationId is zero)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: 0 },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for invalid body (notificationId is string)', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: 'abc' },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('succeeds when all is false but notificationId is valid', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationId: 7, all: false },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ success: boolean }>()
+      expect(body.success).toBe(true)
+      expect(mockDb.update).toHaveBeenCalledOnce()
+    })
   })
 
   // =========================================================================
@@ -512,6 +1125,107 @@ describe('notification routes', () => {
 
       expect(response.statusCode).toBe(401)
       await noAuthApp.close()
+    })
+
+    it('defaults to 0 when count result is empty array', async () => {
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications/count',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ unread: number }>()
+      expect(body.unread).toBe(0)
+    })
+
+    it('defaults to 0 when count result row has undefined count', async () => {
+      selectChain.where.mockResolvedValueOnce([{ count: undefined }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications/count',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ unread: number }>()
+      expect(body.unread).toBe(0)
+    })
+
+    it('returns large unread count correctly', async () => {
+      selectChain.where.mockResolvedValueOnce([{ count: 9999 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/notifications/count',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ unread: number }>()
+      expect(body.unread).toBe(9999)
+    })
+  })
+
+  // =========================================================================
+  // Defensive guards: handler-level !user checks (lines 124, 226, 286)
+  // =========================================================================
+  // These cover the defensive `if (!user)` branches inside each handler body.
+  // Normally requireAuth prevents reaching them, but these guards protect
+  // against a misconfigured auth middleware.
+  // =========================================================================
+
+  describe('handler-level auth guards (passthrough auth)', () => {
+    let passthroughApp: FastifyInstance
+
+    beforeAll(async () => {
+      passthroughApp = await buildTestAppWithPassthroughAuth()
+    })
+
+    afterAll(async () => {
+      await passthroughApp.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('GET /api/notifications returns 401 when user is not set on request', async () => {
+      const response = await passthroughApp.inject({
+        method: 'GET',
+        url: '/api/notifications',
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('PUT /api/notifications/read returns 401 when user is not set on request', async () => {
+      const response = await passthroughApp.inject({
+        method: 'PUT',
+        url: '/api/notifications/read',
+        payload: { all: true },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('GET /api/notifications/count returns 401 when user is not set on request', async () => {
+      const response = await passthroughApp.inject({
+        method: 'GET',
+        url: '/api/notifications/count',
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
     })
   })
 })

--- a/tests/unit/routes/profiles.test.ts
+++ b/tests/unit/routes/profiles.test.ts
@@ -160,6 +160,21 @@ const mockLogger = {
 }
 
 // ---------------------------------------------------------------------------
+// Auth middleware variant that passes through without setting user
+// (simulates a broken auth state where preHandler does not reject but user is unset)
+// ---------------------------------------------------------------------------
+
+function createPassthroughAuthMiddleware(): AuthMiddleware {
+  return {
+    requireAuth: async (_request, _reply) => {
+      // Intentionally does NOT set request.user and does NOT send 401
+      // This lets us exercise the defensive !requestUser guard inside handlers
+    },
+    optionalAuth: (_request, _reply) => Promise.resolve(),
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helper: build app with mocked deps
 // ---------------------------------------------------------------------------
 
@@ -187,6 +202,43 @@ async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
   app.decorateRequest('user', undefined as RequestUser | undefined)
 
   // Override the logger so we can capture log calls
+  app.log.info = mockLogger.info
+  app.log.warn = mockLogger.warn
+  app.log.error = mockLogger.error
+
+  await app.register(profileRoutes())
+  await app.ready()
+
+  return app
+}
+
+/**
+ * Build an app where requireAuth passes through WITHOUT setting request.user.
+ * This exercises the defensive `if (!requestUser)` guards inside handlers.
+ */
+async function buildPassthroughAuthApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false })
+
+  app.decorate('db', mockDb as never)
+  app.decorate('env', mockEnv)
+  app.decorate('authMiddleware', createPassthroughAuthMiddleware())
+  app.decorate('firehose', {} as never)
+  app.decorate('oauthClient', {} as never)
+  app.decorate('sessionService', {} as SessionService)
+  app.decorate('setupService', {} as SetupService)
+  app.decorate('cache', {} as never)
+  app.decorate('trustGraphService', {
+    computeTrustScores: vi.fn().mockResolvedValue({
+      totalNodes: 0,
+      totalEdges: 0,
+      iterations: 0,
+      converged: true,
+      durationMs: 0,
+    }),
+    getTrustScore: vi.fn().mockResolvedValue(1.0),
+  } as never)
+  app.decorateRequest('user', undefined as RequestUser | undefined)
+
   app.log.info = mockLogger.info
   app.log.warn = mockLogger.warn
   app.log.error = mockLogger.error
@@ -370,6 +422,56 @@ describe('profile routes', () => {
       expect(response.statusCode).toBe(404)
     })
 
+    it('falls back to zero when activity count results are empty arrays', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // All count queries return empty arrays (no [0].count)
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        activity: {
+          topicCount: number
+          replyCount: number
+          reactionsReceived: number
+        }
+      }>()
+      expect(body.activity.topicCount).toBe(0)
+      expect(body.activity.replyCount).toBe(0)
+      expect(body.activity.reactionsReceived).toBe(0)
+    })
+
+    it('returns null for displayName and avatarUrl when user fields are undefined', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleUserRow({ displayName: undefined, avatarUrl: undefined }),
+      ])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        displayName: string | null
+        avatarUrl: string | null
+      }>()
+      expect(body.displayName).toBeNull()
+      expect(body.avatarUrl).toBeNull()
+    })
+
     it('serializes dates as ISO strings', async () => {
       selectChain.where.mockResolvedValueOnce([sampleUserRow()])
       selectChain.where.mockResolvedValueOnce([{ count: 0 }])
@@ -531,6 +633,362 @@ describe('profile routes', () => {
       expect(body.communityCount).toBe(3) // comm-a, comm-b, comm-c (deduplicated)
     })
 
+    it('uses fallback trust score of 0.1 when trustGraphService.getTrustScore rejects', async () => {
+      const trustApp = await buildTestApp(testUser())
+      // Override trustGraphService to reject
+      ;(
+        trustApp as unknown as { trustGraphService: { getTrustScore: ReturnType<typeof vi.fn> } }
+      ).trustGraphService.getTrustScore = vi.fn().mockRejectedValue(new Error('trust service down'))
+
+      resetAllDbMocks()
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on topics: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await trustApp.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // baseReputation = 10 * 5 = 50; voterTrustScore = 0.1; pdsTrustFactor = 1.0; clusterDiversity = 1.0
+      // reputation = Math.round(50 * 0.1 * 1.0 * 1.0) = 5
+      expect(body.reputation).toBe(5)
+
+      await trustApp.close()
+    })
+
+    it('uses default PDS trust factor 0.3 when no PDS row is found', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on topics: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor: no rows found -> default 0.3
+      selectChain.where.mockResolvedValueOnce([])
+      // Sybil cluster check: not in any cluster
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // baseReputation = 10 * 5 = 50; voterTrustScore = 1.0; pdsTrustFactor = 0.3; clusterDiversity = 1.0
+      // reputation = Math.round(50 * 1.0 * 0.3 * 1.0) = 15
+      expect(body.reputation).toBe(15)
+    })
+
+    it('uses default PDS trust factor 0.3 when PDS lookup throws', async () => {
+      // Use a user whose handle has only one segment (edge case for PDS host extraction)
+      selectChain.where.mockResolvedValueOnce([sampleUserRow({ handle: 'localhost' })])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on topics: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions on replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor: query throws an error
+      selectChain.where.mockRejectedValueOnce(new Error('PDS lookup failed'))
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/localhost/reputation',
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // baseReputation = 50; voterTrustScore = 1.0; pdsTrustFactor = 0.3 (catch default); clusterDiversity = 1.0
+      expect(body.reputation).toBe(15)
+    })
+
+    it('extracts single-segment handle as PDS host when handle has no dots', async () => {
+      // User with single-segment handle
+      selectChain.where.mockResolvedValueOnce([sampleUserRow({ handle: 'singlepart' })])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor: found for the single-segment host
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 0.8 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/singlepart/reputation',
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // handleParts.length = 1, so pdsHost = user.handle = 'singlepart'
+      // baseReputation = 50; voterTrustScore = 1.0; pdsTrustFactor = 0.8; clusterDiversity = 1.0
+      // reputation = Math.round(50 * 1.0 * 0.8 * 1.0) = 40
+      expect(body.reputation).toBe(40)
+    })
+
+    it('applies sybil cluster penalty for user in flagged cluster with no external interactions', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster members: user is in cluster 1
+      selectChain.where.mockResolvedValueOnce([{ clusterId: 1 }])
+      // Flagged clusters: cluster 1 is flagged
+      selectChain.where.mockResolvedValueOnce([{ id: 1 }])
+      // External interaction count: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // clusterDiversityFactor = log2(1 + 0) = log2(1) = 0
+      // reputation = Math.round(50 * 1.0 * 1.0 * 0) = 0
+      expect(body.reputation).toBe(0)
+    })
+
+    it('applies reduced sybil cluster penalty when user has external interactions', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster members: user is in cluster 1
+      selectChain.where.mockResolvedValueOnce([{ clusterId: 1 }])
+      // Flagged clusters: cluster 1 is flagged
+      selectChain.where.mockResolvedValueOnce([{ id: 1 }])
+      // External interaction count: 7
+      selectChain.where.mockResolvedValueOnce([{ count: 7 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // clusterDiversityFactor = log2(1 + 7) = log2(8) = 3
+      // reputation = Math.round(50 * 1.0 * 1.0 * 3) = 150
+      expect(body.reputation).toBe(150)
+    })
+
+    it('does not apply sybil penalty when user is in cluster but cluster is not flagged', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster members: user is in cluster 1
+      selectChain.where.mockResolvedValueOnce([{ clusterId: 1 }])
+      // Flagged clusters: none flagged (empty result)
+      selectChain.where.mockResolvedValueOnce([])
+      // Community counts (no external interaction query since not flagged)
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // inFlaggedCluster = false, so clusterDiversityFactor = 1.0
+      // reputation = Math.round(50 * 1.0 * 1.0 * 1.0) = 50
+      expect(body.reputation).toBe(50)
+    })
+
+    it('defaults to no cluster adjustment when sybil lookup throws', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster lookup: throws
+      selectChain.where.mockRejectedValueOnce(new Error('sybil lookup failed'))
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // inFlaggedCluster = false (catch default), clusterDiversityFactor = 1.0
+      // reputation = Math.round(50 * 1.0 * 1.0 * 1.0) = 50
+      expect(body.reputation).toBe(50)
+    })
+
+    it('falls back to zero when reputation count results are empty arrays', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // All count queries return empty arrays
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+      selectChain.where.mockResolvedValueOnce([])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        reputation: number
+        breakdown: {
+          topicCount: number
+          replyCount: number
+          reactionsReceived: number
+        }
+      }>()
+      expect(body.reputation).toBe(0)
+      expect(body.breakdown.topicCount).toBe(0)
+      expect(body.breakdown.replyCount).toBe(0)
+      expect(body.breakdown.reactionsReceived).toBe(0)
+    })
+
+    it('falls back to zero external interactions when count result is empty', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster members: user is in cluster 1
+      selectChain.where.mockResolvedValueOnce([{ clusterId: 1 }])
+      // Flagged clusters: cluster 1 is flagged
+      selectChain.where.mockResolvedValueOnce([{ id: 1 }])
+      // External interactions: empty result (no [0].count)
+      selectChain.where.mockResolvedValueOnce([])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // externalInteractionCount = 0 (fallback), clusterDiversityFactor = log2(1+0) = 0
+      expect(body.reputation).toBe(0)
+    })
+
+    it('handles user in multiple sybil clusters', async () => {
+      // User lookup
+      selectChain.where.mockResolvedValueOnce([sampleUserRow()])
+      // Topics: 10
+      selectChain.where.mockResolvedValueOnce([{ count: 10 }])
+      // Replies: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // Reactions: 0
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      selectChain.where.mockResolvedValueOnce([{ count: 0 }])
+      // PDS trust factor
+      selectChain.where.mockResolvedValueOnce([{ trustFactor: 1.0 }])
+      // Sybil cluster members: user is in clusters 1 and 2
+      selectChain.where.mockResolvedValueOnce([{ clusterId: 1 }, { clusterId: 2 }])
+      // Flagged clusters: cluster 2 is flagged
+      selectChain.where.mockResolvedValueOnce([{ id: 2 }])
+      // External interactions: 3
+      selectChain.where.mockResolvedValueOnce([{ count: 3 }])
+      // Community counts
+      selectDistinctChain.where.mockResolvedValueOnce([])
+      selectDistinctChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/${TEST_HANDLE}/reputation`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ reputation: number }>()
+      // clusterDiversityFactor = log2(1 + 3) = log2(4) = 2
+      // reputation = Math.round(50 * 1.0 * 1.0 * 2) = 100
+      expect(body.reputation).toBe(100)
+    })
+
     it('counts distinct communities across topics and replies', async () => {
       // User lookup
       selectChain.where.mockResolvedValueOnce([sampleUserRow()])
@@ -650,6 +1108,61 @@ describe('profile routes', () => {
 
       expect(response.statusCode).toBe(400)
     })
+
+    it('accepts all valid declared age values (13, 14, 15, 18)', async () => {
+      for (const age of [13, 14, 15, 18]) {
+        vi.clearAllMocks()
+        resetAllDbMocks()
+
+        const response = await app.inject({
+          method: 'POST',
+          url: '/api/users/me/age-declaration',
+          headers: { authorization: 'Bearer test-token' },
+          payload: { declaredAge: age },
+        })
+
+        expect(response.statusCode).toBe(200)
+        const body = response.json<{ success: boolean; declaredAge: number }>()
+        expect(body.success).toBe(true)
+        expect(body.declaredAge).toBe(age)
+      }
+    })
+
+    it('returns 400 for negative declaredAge', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/users/me/age-declaration',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { declaredAge: -1 },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('returns 400 for non-integer declaredAge', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/users/me/age-declaration',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { declaredAge: 16.5 },
+      })
+
+      // Fastify schema validation rejects non-integer before our Zod check
+      expect(response.statusCode).toBe(400)
+    })
+
+    it('calls both insert (upsert) and update on users table', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/users/me/age-declaration',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { declaredAge: 18 },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(mockDb.insert).toHaveBeenCalledOnce()
+      expect(mockDb.update).toHaveBeenCalledOnce()
+    })
   })
 
   // =========================================================================
@@ -712,6 +1225,74 @@ describe('profile routes', () => {
       expect(body.mutedWords).toEqual([])
       expect(body.crossPostBluesky).toBe(false)
       expect(body.crossPostFrontpage).toBe(false)
+    })
+
+    it('returns declaredAge as null when prefs.declaredAge is undefined', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ declaredAge: undefined })])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ declaredAge: number | null }>()
+      expect(body.declaredAge).toBeNull()
+    })
+
+    it('returns declaredAge value when set', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ declaredAge: 18 })])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ declaredAge: number | null }>()
+      expect(body.declaredAge).toBe(18)
+    })
+
+    it('returns all preference fields from existing row', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        samplePrefsRow({
+          maturityLevel: 'mature',
+          declaredAge: 16,
+          mutedWords: ['spam', 'ads'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          crossPostBluesky: true,
+          crossPostFrontpage: true,
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityLevel: string
+        declaredAge: number | null
+        mutedWords: string[]
+        blockedDids: string[]
+        mutedDids: string[]
+        crossPostBluesky: boolean
+        crossPostFrontpage: boolean
+        updatedAt: string
+      }>()
+      expect(body.maturityLevel).toBe('mature')
+      expect(body.declaredAge).toBe(16)
+      expect(body.mutedWords).toEqual(['spam', 'ads'])
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+      expect(body.crossPostBluesky).toBe(true)
+      expect(body.crossPostFrontpage).toBe(true)
+      expect(body.updatedAt).toBe(TEST_NOW)
     })
 
     it('returns 401 when not authenticated', async () => {
@@ -799,6 +1380,178 @@ describe('profile routes', () => {
 
       expect(response.statusCode).toBe(400)
     })
+
+    it('returns defaults when preferences row not found after upsert', async () => {
+      // The select after upsert returns empty
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { maturityLevel: 'sfw' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityLevel: string
+        mutedWords: string[]
+        crossPostBluesky: boolean
+        crossPostFrontpage: boolean
+      }>()
+      expect(body.maturityLevel).toBe('sfw')
+      expect(body.mutedWords).toEqual([])
+      expect(body.crossPostBluesky).toBe(false)
+      expect(body.crossPostFrontpage).toBe(false)
+    })
+
+    it('only sets provided fields in the update (partial update with blockedDids only)', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        samplePrefsRow({ blockedDids: ['did:plc:blocked1'] }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { blockedDids: ['did:plc:blocked1'] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ blockedDids: string[] }>()
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+      expect(mockDb.insert).toHaveBeenCalledOnce()
+    })
+
+    it('only sets provided fields in the update (partial update with mutedDids only)', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ mutedDids: ['did:plc:muted1'] })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedDids: ['did:plc:muted1'] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ mutedDids: string[] }>()
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+    })
+
+    it('only sets provided fields in the update (crossPostBluesky only)', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ crossPostBluesky: true })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { crossPostBluesky: true },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ crossPostBluesky: boolean }>()
+      expect(body.crossPostBluesky).toBe(true)
+    })
+
+    it('only sets provided fields in the update (crossPostFrontpage only)', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ crossPostFrontpage: true })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { crossPostFrontpage: true },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ crossPostFrontpage: boolean }>()
+      expect(body.crossPostFrontpage).toBe(true)
+    })
+
+    it('sets all fields when all are provided', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        samplePrefsRow({
+          maturityLevel: 'mature',
+          mutedWords: ['spoiler'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          crossPostBluesky: true,
+          crossPostFrontpage: true,
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: {
+          maturityLevel: 'mature',
+          mutedWords: ['spoiler'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          crossPostBluesky: true,
+          crossPostFrontpage: true,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityLevel: string
+        mutedWords: string[]
+        blockedDids: string[]
+        mutedDids: string[]
+        crossPostBluesky: boolean
+        crossPostFrontpage: boolean
+      }>()
+      expect(body.maturityLevel).toBe('mature')
+      expect(body.mutedWords).toEqual(['spoiler'])
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+      expect(body.crossPostBluesky).toBe(true)
+      expect(body.crossPostFrontpage).toBe(true)
+    })
+
+    it('sets no optional fields when empty body is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow()])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ maturityLevel: string }>()
+      expect(body.maturityLevel).toBe('sfw')
+    })
+
+    it('returns declaredAge as null when prefs row has no declaredAge', async () => {
+      selectChain.where.mockResolvedValueOnce([samplePrefsRow({ declaredAge: undefined })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ declaredAge: number | null }>()
+      expect(body.declaredAge).toBeNull()
+    })
+
+    it('returns 400 when Zod validation fails (mutedWords with empty string)', async () => {
+      // Passes Fastify JSON schema (array of strings) but fails Zod (.min(1) on string items)
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedWords: [''] },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
   })
 
   // =========================================================================
@@ -870,6 +1623,88 @@ describe('profile routes', () => {
       expect(body.communityDid).toBe(COMMUNITY_DID)
       expect(body.maturityOverride).toBeNull()
       expect(body.mutedWords).toBeNull()
+      expect(body.notificationPrefs).toBeNull()
+    })
+
+    it('returns existing values including non-null fields', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: 'sfw',
+          mutedWords: ['spam'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          notificationPrefs: {
+            replies: true,
+            reactions: true,
+            mentions: false,
+            modActions: true,
+          },
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        communityDid: string
+        maturityOverride: string | null
+        mutedWords: string[] | null
+        blockedDids: string[] | null
+        mutedDids: string[] | null
+        notificationPrefs: {
+          replies: boolean
+          reactions: boolean
+          mentions: boolean
+          modActions: boolean
+        } | null
+        updatedAt: string
+      }>()
+      expect(body.maturityOverride).toBe('sfw')
+      expect(body.mutedWords).toEqual(['spam'])
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+      expect(body.notificationPrefs).toEqual({
+        replies: true,
+        reactions: true,
+        mentions: false,
+        modActions: true,
+      })
+      expect(body.updatedAt).toBe(TEST_NOW)
+    })
+
+    it('returns null for undefined community preference fields (fallback via ??)', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: undefined,
+          mutedWords: undefined,
+          blockedDids: undefined,
+          mutedDids: undefined,
+          notificationPrefs: undefined,
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityOverride: null
+        mutedWords: null
+        blockedDids: null
+        mutedDids: null
+        notificationPrefs: null
+      }>()
+      expect(body.maturityOverride).toBeNull()
+      expect(body.mutedWords).toBeNull()
+      expect(body.blockedDids).toBeNull()
+      expect(body.mutedDids).toBeNull()
       expect(body.notificationPrefs).toBeNull()
     })
 
@@ -960,6 +1795,268 @@ describe('profile routes', () => {
 
       expect(response.statusCode).toBe(400)
     })
+
+    it('returns defaults when preferences row not found after upsert', async () => {
+      // The select after upsert returns empty
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { maturityOverride: 'sfw' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        communityDid: string
+        maturityOverride: null
+        mutedWords: null
+        blockedDids: null
+        mutedDids: null
+        notificationPrefs: null
+      }>()
+      expect(body.communityDid).toBe(COMMUNITY_DID)
+      expect(body.maturityOverride).toBeNull()
+      expect(body.mutedWords).toBeNull()
+      expect(body.notificationPrefs).toBeNull()
+    })
+
+    it('only sets maturityOverride when only maturityOverride is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({ maturityOverride: 'mature' }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { maturityOverride: 'mature' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ maturityOverride: string }>()
+      expect(body.maturityOverride).toBe('mature')
+    })
+
+    it('only sets mutedWords when only mutedWords is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleCommunityPrefsRow({ mutedWords: ['spam'] })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedWords: ['spam'] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ mutedWords: string[] }>()
+      expect(body.mutedWords).toEqual(['spam'])
+    })
+
+    it('only sets blockedDids when only blockedDids is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({ blockedDids: ['did:plc:blocked1'] }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { blockedDids: ['did:plc:blocked1'] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ blockedDids: string[] }>()
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+    })
+
+    it('only sets mutedDids when only mutedDids is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({ mutedDids: ['did:plc:muted1'] }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedDids: ['did:plc:muted1'] },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ mutedDids: string[] }>()
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+    })
+
+    it('only sets notificationPrefs when only notificationPrefs is provided', async () => {
+      const notifPrefs = {
+        replies: false,
+        reactions: true,
+        mentions: true,
+        modActions: false,
+      }
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({ notificationPrefs: notifPrefs }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { notificationPrefs: notifPrefs },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        notificationPrefs: {
+          replies: boolean
+          reactions: boolean
+          mentions: boolean
+          modActions: boolean
+        }
+      }>()
+      expect(body.notificationPrefs).toEqual(notifPrefs)
+    })
+
+    it('sets all fields when all are provided', async () => {
+      const notifPrefs = {
+        replies: true,
+        reactions: true,
+        mentions: true,
+        modActions: true,
+      }
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: 'mature',
+          mutedWords: ['spoiler'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          notificationPrefs: notifPrefs,
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: {
+          maturityOverride: 'mature',
+          mutedWords: ['spoiler'],
+          blockedDids: ['did:plc:blocked1'],
+          mutedDids: ['did:plc:muted1'],
+          notificationPrefs: notifPrefs,
+        },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityOverride: string
+        mutedWords: string[]
+        blockedDids: string[]
+        mutedDids: string[]
+        notificationPrefs: {
+          replies: boolean
+          reactions: boolean
+          mentions: boolean
+          modActions: boolean
+        }
+      }>()
+      expect(body.maturityOverride).toBe('mature')
+      expect(body.mutedWords).toEqual(['spoiler'])
+      expect(body.blockedDids).toEqual(['did:plc:blocked1'])
+      expect(body.mutedDids).toEqual(['did:plc:muted1'])
+      expect(body.notificationPrefs).toEqual(notifPrefs)
+    })
+
+    it('sets no optional fields when empty body is provided', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleCommunityPrefsRow()])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ communityDid: string }>()
+      expect(body.communityDid).toBe(COMMUNITY_DID)
+    })
+
+    it('allows setting maturityOverride to null', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleCommunityPrefsRow({ maturityOverride: null })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { maturityOverride: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ maturityOverride: null }>()
+      expect(body.maturityOverride).toBeNull()
+    })
+
+    it('allows setting mutedWords to null', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleCommunityPrefsRow({ mutedWords: null })])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedWords: null },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ mutedWords: null }>()
+      expect(body.mutedWords).toBeNull()
+    })
+
+    it('returns null for undefined community preference fields after upsert (fallback via ??)', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        sampleCommunityPrefsRow({
+          maturityOverride: undefined,
+          mutedWords: undefined,
+          blockedDids: undefined,
+          mutedDids: undefined,
+          notificationPrefs: undefined,
+        }),
+      ])
+
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: {},
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        maturityOverride: null
+        mutedWords: null
+        blockedDids: null
+        mutedDids: null
+        notificationPrefs: null
+      }>()
+      expect(body.maturityOverride).toBeNull()
+      expect(body.mutedWords).toBeNull()
+      expect(body.blockedDids).toBeNull()
+      expect(body.mutedDids).toBeNull()
+      expect(body.notificationPrefs).toBeNull()
+    })
+
+    it('returns 400 when Zod validation fails (mutedWords with empty string)', async () => {
+      // Passes Fastify JSON schema but fails Zod (.min(1) on string items)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { mutedWords: [''] },
+      })
+
+      expect(response.statusCode).toBe(400)
+    })
   })
 
   // =========================================================================
@@ -1022,6 +2119,99 @@ describe('profile routes', () => {
         { did: TEST_DID },
         'GDPR Art. 17: all indexed data purged for user'
       )
+    })
+  })
+
+  // =========================================================================
+  // Defensive guard tests: !requestUser inside handlers
+  // =========================================================================
+  // These test the fallback 401 guards inside route handlers that fire when
+  // requireAuth somehow passes through without setting request.user.
+  // =========================================================================
+
+  describe('defensive !requestUser guards (passthrough auth)', () => {
+    let passthroughApp: FastifyInstance
+
+    beforeAll(async () => {
+      passthroughApp = await buildPassthroughAuthApp()
+    })
+
+    afterAll(async () => {
+      await passthroughApp.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('POST /api/users/me/age-declaration returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'POST',
+        url: '/api/users/me/age-declaration',
+        payload: { declaredAge: 18 },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('GET /api/users/me/preferences returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences',
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('PUT /api/users/me/preferences returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'PUT',
+        url: '/api/users/me/preferences',
+        payload: { maturityLevel: 'sfw' },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('GET /api/users/me/communities/:communityId/preferences returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'GET',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('PUT /api/users/me/communities/:communityId/preferences returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'PUT',
+        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        payload: { maturityOverride: 'sfw' },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('DELETE /api/users/me returns 401 when request.user is undefined', async () => {
+      const response = await passthroughApp.inject({
+        method: 'DELETE',
+        url: '/api/users/me',
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
     })
   })
 })

--- a/tests/unit/routes/replies.test.ts
+++ b/tests/unit/routes/replies.test.ts
@@ -58,6 +58,14 @@ vi.mock('../../../src/lib/anti-spam.js', () => ({
   runAntiSpamChecks: vi.fn().mockResolvedValue({ held: false, reasons: [] }),
 }))
 
+// Import anti-spam mocks for per-test override
+import {
+  isAccountTrusted as isAccountTrustedMock,
+  checkWriteRateLimit as checkWriteRateLimitMock,
+  runAntiSpamChecks as runAntiSpamChecksMock,
+  isNewAccount as isNewAccountMock,
+} from '../../../src/lib/anti-spam.js'
+
 // Import routes AFTER mocking
 import { replyRoutes } from '../../../src/routes/replies.js'
 
@@ -178,6 +186,21 @@ function createMockAuthMiddleware(user?: RequestUser): AuthMiddleware {
   }
 }
 
+/**
+ * Special auth middleware that passes through without setting user.
+ * This tests the defensive `if (!user)` guards inside route handlers.
+ */
+function createPassthroughAuthMiddleware(): AuthMiddleware {
+  return {
+    requireAuth: async (_request, _reply) => {
+      // Intentionally does not set request.user or send 401
+    },
+    optionalAuth: (_request, _reply) => {
+      return Promise.resolve()
+    },
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Sample row builders
 // ---------------------------------------------------------------------------
@@ -233,12 +256,38 @@ function sampleReplyRow(overrides?: Record<string, unknown>) {
 // Helper: build app with mocked deps
 // ---------------------------------------------------------------------------
 
-async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
+interface BuildTestAppOptions {
+  user?: RequestUser
+  ozoneService?: {
+    isSpamLabeled: ReturnType<typeof vi.fn>
+    batchIsSpamLabeled: ReturnType<typeof vi.fn>
+  }
+  passthroughAuth?: boolean
+}
+
+async function buildTestApp(
+  userOrOpts?: RequestUser | BuildTestAppOptions
+): Promise<FastifyInstance> {
+  // Support both old signature (user) and new signature (options object)
+  let user: RequestUser | undefined
+  let ozoneService: BuildTestAppOptions['ozoneService']
+  let passthroughAuth = false
+  if (userOrOpts && 'did' in userOrOpts) {
+    user = userOrOpts
+  } else if (userOrOpts && typeof userOrOpts === 'object' && !('did' in userOrOpts)) {
+    user = userOrOpts.user
+    ozoneService = userOrOpts.ozoneService
+    passthroughAuth = userOrOpts.passthroughAuth ?? false
+  }
+
   const app = Fastify({ logger: false })
 
   app.decorate('db', mockDb as never)
   app.decorate('env', mockEnv)
-  app.decorate('authMiddleware', createMockAuthMiddleware(user))
+  app.decorate(
+    'authMiddleware',
+    passthroughAuth ? createPassthroughAuthMiddleware() : createMockAuthMiddleware(user)
+  )
   app.decorate('firehose', mockFirehose as never)
   app.decorate('oauthClient', {} as never)
   app.decorate('sessionService', {} as SessionService)
@@ -249,6 +298,9 @@ async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
     recordReaction: vi.fn().mockResolvedValue(undefined),
     recordCoParticipation: vi.fn().mockResolvedValue(undefined),
   } as never)
+  if (ozoneService) {
+    app.decorate('ozoneService', ozoneService as never)
+  }
   app.decorateRequest('user', undefined as RequestUser | undefined)
 
   await app.register(replyRoutes())
@@ -1407,6 +1459,1050 @@ describe('reply routes', () => {
       })
 
       expect(response.statusCode).toBe(401)
+    })
+  })
+
+  // =========================================================================
+  // Additional branch coverage tests
+  // =========================================================================
+
+  describe('POST /api/topics/:topicUri/replies (onboarding gate)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      createRecordFn.mockResolvedValue({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValue(true)
+    })
+
+    it('returns 403 when onboarding is incomplete', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Onboarding: mandatory fields exist
+      selectChain.where.mockResolvedValueOnce([
+        {
+          id: 'field1',
+          label: 'Accept Rules',
+          fieldType: 'checkbox',
+          isMandatory: true,
+          communityDid: 'did:plc:community123',
+        },
+      ])
+      // Onboarding: user responses (none)
+      selectChain.where.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'My reply.' },
+      })
+
+      expect(response.statusCode).toBe(403)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Onboarding required')
+    })
+  })
+
+  describe('POST /api/topics/:topicUri/replies (anti-spam branches)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      createRecordFn.mockResolvedValue({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValue(true)
+    })
+
+    it('returns 429 when write rate limit is exceeded for untrusted user', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      // Override anti-spam mocks for this test
+      vi.mocked(isAccountTrustedMock).mockResolvedValueOnce(false)
+      vi.mocked(isNewAccountMock).mockResolvedValueOnce(true)
+      vi.mocked(checkWriteRateLimitMock).mockResolvedValueOnce(true)
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Rate limited reply.' },
+      })
+
+      expect(response.statusCode).toBe(429)
+    })
+
+    it('holds reply for moderation when anti-spam check flags content', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      // Anti-spam: content held
+      vi.mocked(runAntiSpamChecksMock).mockResolvedValueOnce({
+        held: true,
+        reasons: [
+          { reason: 'word_filter', matchedWords: ['spam'] },
+          { reason: 'first_post_queue' },
+        ],
+      })
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Spam content here.' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const body = response.json<{ moderationStatus: string }>()
+      expect(body.moderationStatus).toBe('held')
+
+      // Verify moderation queue entries were inserted
+      // insert is called twice: once for reply, once for moderation queue
+      expect(mockDb.insert).toHaveBeenCalledTimes(2)
+
+      // Verify topic replyCount was NOT updated (held replies are not counted)
+      expect(mockDb.update).not.toHaveBeenCalled()
+    })
+
+    it('creates approved reply and updates topic replyCount when not held', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      vi.mocked(runAntiSpamChecksMock).mockResolvedValueOnce({
+        held: false,
+        reasons: [],
+      })
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Approved reply.' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      const body = response.json<{ moderationStatus: string }>()
+      expect(body.moderationStatus).toBe('approved')
+
+      // Topic replyCount should have been updated
+      expect(mockDb.update).toHaveBeenCalled()
+    })
+
+    it('untrusted user that is not new still gets anti-spam checks', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      // Not trusted but also not new, and not rate limited
+      vi.mocked(isAccountTrustedMock).mockResolvedValueOnce(false)
+      vi.mocked(isNewAccountMock).mockResolvedValueOnce(false)
+      vi.mocked(checkWriteRateLimitMock).mockResolvedValueOnce(false)
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Non-trusted, non-new reply.' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(vi.mocked(isNewAccountMock)).toHaveBeenCalled()
+      expect(vi.mocked(checkWriteRateLimitMock)).toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/topics/:topicUri/replies (ozone service)', () => {
+    let app: FastifyInstance
+    const mockOzoneService = {
+      isSpamLabeled: vi.fn().mockResolvedValue(false),
+      batchIsSpamLabeled: vi.fn().mockResolvedValue(new Map()),
+    }
+
+    beforeAll(async () => {
+      app = await buildTestApp({
+        user: testUser(),
+        ozoneService: mockOzoneService,
+      })
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      createRecordFn.mockResolvedValue({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValue(true)
+      mockOzoneService.isSpamLabeled.mockResolvedValue(false)
+    })
+
+    it('checks ozone spam label when ozone service is available', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Reply with ozone check.' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(mockOzoneService.isSpamLabeled).toHaveBeenCalledWith(TEST_DID)
+    })
+
+    it('treats ozone spam-labeled user as new (stricter rate limits)', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      mockOzoneService.isSpamLabeled.mockResolvedValueOnce(true)
+
+      // Spam-labeled means isAccountTrusted check returns false due to ozoneSpamLabeled
+      vi.mocked(isAccountTrustedMock).mockResolvedValueOnce(false)
+      // Rate limit not exceeded
+      vi.mocked(checkWriteRateLimitMock).mockResolvedValueOnce(false)
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Ozone spam labeled user reply.' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      // isNewAccount should NOT be called because ozoneSpamLabeled short-circuits to isNew = true
+      expect(vi.mocked(isNewAccountMock)).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/topics/:topicUri/replies (PDS and DB error re-throws)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      createRecordFn.mockResolvedValue({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValue(true)
+    })
+
+    it('re-throws PDS error with statusCode property', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      const httpError = new Error('Upstream error') as Error & { statusCode: number }
+      httpError.statusCode = 503
+      createRecordFn.mockRejectedValueOnce(httpError)
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'PDS error with status code.' },
+      })
+
+      // The error with statusCode is re-thrown, Fastify converts it to that status
+      expect(response.statusCode).toBe(503)
+    })
+
+    it('returns 500 when local DB save fails after PDS write', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      createRecordFn.mockResolvedValueOnce({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValueOnce(true)
+
+      // Make the DB insert throw
+      insertChain.values.mockImplementationOnce(() => {
+        throw new Error('DB connection lost')
+      })
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'DB will fail.' },
+      })
+
+      expect(response.statusCode).toBe(500)
+    })
+
+    it('re-throws DB error with statusCode property in post-PDS catch block', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      createRecordFn.mockResolvedValueOnce({ uri: TEST_REPLY_URI, cid: TEST_REPLY_CID })
+      isTrackedFn.mockResolvedValueOnce(true)
+
+      const httpError = new Error('Already exists') as Error & { statusCode: number }
+      httpError.statusCode = 409
+      insertChain.values.mockImplementationOnce(() => {
+        throw httpError
+      })
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'DB error with status.' },
+      })
+
+      expect(response.statusCode).toBe(409)
+    })
+  })
+
+  describe('GET /api/topics/:topicUri/replies (maturity filtering)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('returns 403 when category maturity exceeds user max maturity', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow({ category: 'adult-content' })])
+      // Category maturity: adult
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'adult' }])
+      // User profile: safe maturity pref
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: 25, maturityPref: 'safe' }])
+      // Community settings
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(403)
+    })
+
+    it('defaults category maturity to safe when category not found', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Category maturity: empty (not found)
+      selectChain.where.mockResolvedValueOnce([])
+      // User profile
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: 25, maturityPref: 'safe' }])
+      // Community settings
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // Block/mute
+      selectChain.where.mockResolvedValueOnce([])
+      // Replies
+      selectChain.limit.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      // Should still succeed because default maturity is 'safe' which passes
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('defaults ageThreshold to 16 when community settings not found', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Category maturity
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // User profile
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: 25, maturityPref: 'safe' }])
+      // Community settings: not found (empty)
+      selectChain.where.mockResolvedValueOnce([])
+      // Block/mute
+      selectChain.where.mockResolvedValueOnce([])
+      // Replies
+      selectChain.limit.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('handles unauthenticated user with safe maturity only', async () => {
+      const noAuthApp = await buildTestApp(undefined)
+
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Category maturity: safe
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // No user profile query for unauthenticated
+      // Community settings
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // No block/mute for unauthenticated
+      // Replies
+      selectChain.limit.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await noAuthApp.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      await noAuthApp.close()
+    })
+
+    it('handles user with no profile row in DB', async () => {
+      // Topic lookup
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Category maturity
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // User profile: not found (empty)
+      selectChain.where.mockResolvedValueOnce([])
+      // Community settings
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // Block/mute
+      selectChain.where.mockResolvedValueOnce([])
+      // Replies
+      selectChain.limit.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      // User profile not found means userProfile is undefined -> resolveMaxMaturity returns 'safe'
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('GET /api/topics/:topicUri/replies (cursor edge cases)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('ignores invalid cursor (malformed base64)', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      selectChain.limit.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies?cursor=not-valid-base64!!!`,
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('ignores cursor with missing fields', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      selectChain.limit.mockResolvedValueOnce([])
+
+      // Valid base64 but missing required fields
+      const badCursor = Buffer.from(JSON.stringify({ foo: 'bar' })).toString('base64')
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies?cursor=${encodeURIComponent(badCursor)}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('ignores cursor with non-string field values', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      selectChain.limit.mockResolvedValueOnce([])
+
+      // Valid base64 JSON but createdAt is a number
+      const badCursor = Buffer.from(JSON.stringify({ createdAt: 123, uri: 'at://...' })).toString(
+        'base64'
+      )
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies?cursor=${encodeURIComponent(badCursor)}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('GET /api/topics/:topicUri/replies (ozone annotation)', () => {
+    let app: FastifyInstance
+    const mockOzoneService = {
+      isSpamLabeled: vi.fn().mockResolvedValue(false),
+      batchIsSpamLabeled: vi.fn().mockResolvedValue(new Map()),
+    }
+
+    beforeAll(async () => {
+      app = await buildTestApp({
+        user: testUser(),
+        ozoneService: mockOzoneService,
+      })
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('annotates replies with ozone spam labels when service is available', async () => {
+      const spamDid = 'did:plc:spammer'
+
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+      // Category maturity
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // User profile
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: 25, maturityPref: 'safe' }])
+      // Community settings
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // Block/mute (loadBlockMuteLists)
+      selectChain.where.mockResolvedValueOnce([])
+
+      // Replies query uses .where -> chain -> .orderBy -> .limit
+      selectChain.where.mockImplementationOnce(() => selectChain)
+      const rows = [
+        sampleReplyRow({
+          authorDid: spamDid,
+          uri: `at://${spamDid}/forum.barazo.topic.reply/s1`,
+          rkey: 's1',
+        }),
+        sampleReplyRow({ authorDid: TEST_DID }),
+      ]
+      selectChain.limit.mockResolvedValueOnce(rows)
+
+      // Ozone batch: spamDid is spam-labeled, TEST_DID is not
+      mockOzoneService.batchIsSpamLabeled.mockResolvedValueOnce(
+        new Map([
+          [spamDid, true],
+          [TEST_DID, false],
+        ])
+      )
+
+      // resolveAuthors: users table query
+      selectChain.where.mockResolvedValueOnce([
+        {
+          did: spamDid,
+          handle: 'spammer.bsky.social',
+          displayName: 'Spammer',
+          avatarUrl: null,
+          bannerUrl: null,
+          bio: null,
+        },
+        {
+          did: TEST_DID,
+          handle: TEST_HANDLE,
+          displayName: 'Alice',
+          avatarUrl: null,
+          bannerUrl: null,
+          bio: null,
+        },
+      ])
+      // resolveAuthors: community profiles query
+      selectChain.where.mockResolvedValueOnce([])
+      // loadMutedWords: global
+      selectChain.where.mockResolvedValueOnce([])
+      // loadMutedWords: community
+      selectChain.where.mockResolvedValueOnce([])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ authorDid: string; ozoneLabel: string | null }>
+      }>()
+      expect(body.replies).toHaveLength(2)
+
+      const spamReply = body.replies.find((r) => r.authorDid === spamDid)
+      expect(spamReply?.ozoneLabel).toBe('spam')
+
+      const normalReply = body.replies.find((r) => r.authorDid === TEST_DID)
+      expect(normalReply?.ozoneLabel).toBeNull()
+    })
+  })
+
+  describe('GET /api/topics/:topicUri/replies (serializeReply branches)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('returns empty content for author-deleted replies', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const authorDeletedReply = sampleReplyRow({
+        isAuthorDeleted: true,
+        content: 'Original content before deletion',
+        contentFormat: 'markdown',
+      })
+      selectChain.limit.mockResolvedValueOnce([authorDeletedReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ content: string; contentFormat: string | null }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      // Author-deleted replies return empty content
+      expect(body.replies[0]?.content).toBe('')
+      expect(body.replies[0]?.contentFormat).toBeNull()
+    })
+
+    it('returns placeholder content for mod-deleted reply and null contentFormat', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const modDeletedReply = sampleReplyRow({
+        isModDeleted: true,
+        isAuthorDeleted: false,
+        content: 'Violating content',
+        contentFormat: 'markdown',
+      })
+      selectChain.limit.mockResolvedValueOnce([modDeletedReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ content: string; contentFormat: string | null }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.content).toBe('[Removed by moderator]')
+      expect(body.replies[0]?.contentFormat).toBeNull()
+    })
+
+    it('preserves contentFormat for non-deleted replies', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const markdownReply = sampleReplyRow({
+        contentFormat: 'markdown',
+        isAuthorDeleted: false,
+        isModDeleted: false,
+      })
+      selectChain.limit.mockResolvedValueOnce([markdownReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ contentFormat: string | null }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.contentFormat).toBe('markdown')
+    })
+
+    it('returns contentFormat as null when contentFormat is undefined (not deleted)', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const noFormatReply = sampleReplyRow({
+        contentFormat: undefined,
+        isAuthorDeleted: false,
+        isModDeleted: false,
+      })
+      selectChain.limit.mockResolvedValueOnce([noFormatReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ contentFormat: string | null }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.contentFormat).toBeNull()
+    })
+
+    it('prioritizes mod-deleted placeholder over author-deleted when both are true', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const bothDeletedReply = sampleReplyRow({
+        isAuthorDeleted: true,
+        isModDeleted: true,
+        content: 'Original content',
+      })
+      selectChain.limit.mockResolvedValueOnce([bothDeletedReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ content: string }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.content).toBe('[Removed by moderator]')
+    })
+  })
+
+  describe('PUT /api/replies/:uri (error branches)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      updateRecordFn.mockResolvedValue({ uri: TEST_REPLY_URI, cid: 'bafyreinewcid' })
+    })
+
+    it('re-throws PDS error with statusCode property', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      const httpError = new Error('PDS upstream error') as Error & { statusCode: number }
+      httpError.statusCode = 503
+      updateRecordFn.mockRejectedValueOnce(httpError)
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Will fail with statusCode.' },
+      })
+
+      expect(response.statusCode).toBe(503)
+    })
+
+    it('returns 500 when local DB update fails after PDS write', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+
+      // Make the DB update throw
+      updateChain.set.mockImplementationOnce(() => {
+        throw new Error('DB write failed')
+      })
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'DB will fail on update.' },
+      })
+
+      expect(response.statusCode).toBe(500)
+    })
+
+    it('re-throws DB error with statusCode property in post-PDS catch block', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+
+      const httpError = new Error('Conflict') as Error & { statusCode: number }
+      httpError.statusCode = 409
+      updateChain.set.mockImplementationOnce(() => {
+        throw httpError
+      })
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'DB error with status code.' },
+      })
+
+      expect(response.statusCode).toBe(409)
+    })
+
+    it('returns 404 when reply is not found after DB update (returning is empty)', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      // DB returning empty
+      updateChain.returning.mockResolvedValueOnce([])
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'Update but returning empty.' },
+      })
+
+      expect(response.statusCode).toBe(404)
+    })
+
+    it('resolves labels from existing row when labels field is omitted and existing labels are null', async () => {
+      const existingRow = sampleReplyRow({ labels: null })
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      const updatedRow = { ...existingRow, content: 'New content', cid: 'bafyreinewcid' }
+      updateChain.returning.mockResolvedValueOnce([updatedRow])
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'New content' },
+      })
+
+      expect(response.statusCode).toBe(200)
+
+      // PDS record should NOT include labels key since resolvedLabels is null (falsy)
+      const pdsRecord = updateRecordFn.mock.calls[0]?.[3] as Record<string, unknown>
+      expect(pdsRecord).not.toHaveProperty('labels')
+    })
+  })
+
+  describe('DELETE /api/replies/:uri (error branches)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+      deleteRecordFn.mockResolvedValue(undefined)
+    })
+
+    it('re-throws PDS error with statusCode property', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      const httpError = new Error('PDS upstream') as Error & { statusCode: number }
+      httpError.statusCode = 503
+      deleteRecordFn.mockRejectedValueOnce(httpError)
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(503)
+    })
+
+    it('returns 500 when DB transaction fails after PDS delete', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      deleteRecordFn.mockResolvedValueOnce(undefined)
+
+      // Make the transaction throw
+      mockDb.transaction.mockImplementationOnce(() => {
+        throw new Error('Transaction failed')
+      })
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(500)
+    })
+
+    it('re-throws DB error with statusCode property in delete catch block', async () => {
+      const existingRow = sampleReplyRow()
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      deleteRecordFn.mockResolvedValueOnce(undefined)
+
+      const httpError = new Error('DB error') as Error & { statusCode: number }
+      httpError.statusCode = 409
+      mockDb.transaction.mockImplementationOnce(() => {
+        throw httpError
+      })
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(409)
+    })
+
+    it('returns 403 when non-author and user row not found in DB', async () => {
+      const existingRow = sampleReplyRow({ authorDid: OTHER_DID })
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      // User lookup: empty (user not found in DB)
+      selectChain.where.mockResolvedValueOnce([])
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      // userRow is undefined, so isMod = (undefined?.role === 'moderator') = false
+      expect(response.statusCode).toBe(403)
+    })
+
+    it('skips PDS deletion for moderator delete (moderator not author)', async () => {
+      const modApp = await buildTestApp(testUser({ did: MOD_DID, handle: 'mod.bsky.social' }))
+
+      const existingRow = sampleReplyRow({ authorDid: OTHER_DID })
+      selectChain.where.mockResolvedValueOnce([existingRow])
+      selectChain.where.mockResolvedValueOnce([{ did: MOD_DID, role: 'moderator' }])
+
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await modApp.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(204)
+      // PDS deleteRecord should NOT be called for mod deletes
+      expect(deleteRecordFn).not.toHaveBeenCalled()
+      // DB transaction should still be called for soft-delete
+      expect(mockDb.transaction).toHaveBeenCalled()
+
+      await modApp.close()
+    })
+  })
+
+  // =========================================================================
+  // Defensive guard branches (!user checks inside handlers)
+  // =========================================================================
+
+  describe('Defensive user guards (passthrough auth)', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp({ passthroughAuth: true })
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('POST returns 401 from handler-level guard when middleware does not set user', async () => {
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'No user set.' },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('PUT returns 401 from handler-level guard when middleware does not set user', async () => {
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+        payload: { content: 'No user set.' },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
+    })
+
+    it('DELETE returns 401 from handler-level guard when middleware does not set user', async () => {
+      const encodedUri = encodeURIComponent(TEST_REPLY_URI)
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/replies/${encodedUri}`,
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(401)
+      const body = response.json<{ error: string }>()
+      expect(body.error).toBe('Authentication required')
     })
   })
 })

--- a/tests/unit/routes/search.test.ts
+++ b/tests/unit/routes/search.test.ts
@@ -25,6 +25,19 @@ vi.mock('../../../src/services/embedding.js', () => ({
   })),
 }))
 
+// ---------------------------------------------------------------------------
+// Mock muted words (loadMutedWords uses Drizzle query builder, not raw SQL)
+// ---------------------------------------------------------------------------
+
+const mockLoadMutedWords = vi.fn().mockResolvedValue([])
+const mockContentMatchesMutedWords = vi.fn().mockReturnValue(false)
+
+vi.mock('../../../src/lib/muted-words.js', () => ({
+  loadMutedWords: (...args: unknown[]) => mockLoadMutedWords(...args) as Promise<string[]>,
+  contentMatchesMutedWords: (...args: unknown[]) =>
+    mockContentMatchesMutedWords(...args) as boolean,
+}))
+
 // Import routes AFTER mocking
 import { searchRoutes } from '../../../src/routes/search.js'
 
@@ -112,6 +125,8 @@ describe('search routes', () => {
     mockDb.execute.mockResolvedValue([])
     mockIsEnabled.mockReturnValue(false)
     mockGenerateEmbedding.mockResolvedValue(null)
+    mockLoadMutedWords.mockResolvedValue([])
+    mockContentMatchesMutedWords.mockReturnValue(false)
 
     app = await buildTestApp()
   })
@@ -574,5 +589,952 @@ describe('search routes', () => {
     expect(body.results).toHaveLength(1)
     expect(body.results[0]?.type).toBe('reply')
     expect(body.results[0]?.uri).toBe(nonDeletedReply.uri)
+  })
+
+  // =========================================================================
+  // Cursor-based pagination
+  // =========================================================================
+
+  it('accepts a valid cursor and passes decoded values to DB queries', async () => {
+    // Build a valid cursor: base64(JSON({ rank, uri }))
+    const cursorPayload = Buffer.from(
+      JSON.stringify({ rank: 0.5, uri: 'at://did:plc:x/forum.barazo.topic.post/abc' })
+    ).toString('base64')
+
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/search?q=test&cursor=${encodeURIComponent(cursorPayload)}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1)
+    // Two DB calls: topic search + reply search, both should include cursor conditions
+    expect(mockDb.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores an invalid (non-base64) cursor gracefully', async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&cursor=!!!invalid!!!',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1)
+  })
+
+  it('ignores a cursor with invalid JSON structure (missing rank or uri)', async () => {
+    // Valid base64, valid JSON, but wrong shape (no "uri" field)
+    const cursorPayload = Buffer.from(JSON.stringify({ rank: 0.5 })).toString('base64')
+
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/search?q=test&cursor=${encodeURIComponent(cursorPayload)}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1)
+  })
+
+  it('ignores a cursor with wrong types (rank is string instead of number)', async () => {
+    const cursorPayload = Buffer.from(
+      JSON.stringify({ rank: 'not-a-number', uri: 'at://x/y/z' })
+    ).toString('base64')
+
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/search?q=test&cursor=${encodeURIComponent(cursorPayload)}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1)
+  })
+
+  // =========================================================================
+  // Custom limit parameter
+  // =========================================================================
+
+  it('respects a custom limit parameter', async () => {
+    // Set limit=2. Route fetches limit+1=3.
+    // Return 3 rows to trigger hasMore.
+    const rows = Array.from({ length: 3 }, (_, i) =>
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/t${String(i)}`,
+        rkey: `t${String(i)}`,
+        rank: 1.0 - i * 0.1,
+      })
+    )
+
+    mockDb.execute.mockResolvedValueOnce(rows)
+    mockDb.execute.mockResolvedValueOnce([])
+    // Count queries
+    mockDb.execute.mockResolvedValueOnce([{ count: '10' }])
+    mockDb.execute.mockResolvedValueOnce([{ count: '5' }])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=2',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      cursor: string | null
+      total: number
+    }>()
+    expect(body.results).toHaveLength(2)
+    expect(body.cursor).toBeTruthy()
+    expect(body.total).toBe(15) // 10+5
+  })
+
+  // =========================================================================
+  // Global community mode (no community_did filter)
+  // =========================================================================
+
+  it('does not filter by community_did in global mode', async () => {
+    const globalApp = Fastify({ logger: false })
+
+    globalApp.decorateRequest('user', undefined as RequestUser | undefined)
+    globalApp.decorate('db', mockDb as never)
+    globalApp.decorate('env', {
+      EMBEDDING_URL: undefined,
+      AI_EMBEDDING_DIMENSIONS: 768,
+      COMMUNITY_MODE: 'global',
+      COMMUNITY_DID: undefined,
+    } as never)
+    globalApp.decorate('authMiddleware', {
+      requireAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+      optionalAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+    } as never)
+    globalApp.decorate('cache', {} as never)
+
+    await globalApp.register(searchRoutes())
+    await globalApp.ready()
+
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await globalApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ type: string }>
+      searchMode: string
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.type).toBe('topic')
+
+    await globalApp.close()
+  })
+
+  // =========================================================================
+  // Hybrid search: type=topics only (vector topics)
+  // =========================================================================
+
+  it('hybrid search runs vector topic search when type=topics', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+
+    const hybridApp = await buildTestApp()
+
+    const topicRow = sampleTopicRow()
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([topicRow])
+    // Vector topics
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/vectorTopic1`,
+        rkey: 'vectorTopic1',
+        rank: 0.85,
+      }),
+    ])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=topics',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ type: string }>
+      searchMode: string
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    // Should have merged results (RRF fusion)
+    expect(body.results.length).toBeGreaterThanOrEqual(1)
+    // Only 2 DB calls: fulltext topics + vector topics (no replies)
+    expect(mockDb.execute).toHaveBeenCalledTimes(2)
+
+    await hybridApp.close()
+  })
+
+  // =========================================================================
+  // Hybrid search: type=replies only (vector replies)
+  // =========================================================================
+
+  it('hybrid search runs vector reply search when type=replies', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.4, 0.5, 0.6])
+
+    const hybridApp = await buildTestApp()
+
+    const replyRow = sampleReplyRow()
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([replyRow])
+    // Vector replies
+    mockDb.execute.mockResolvedValueOnce([
+      sampleReplyRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.reply/vectorReply1`,
+        rkey: 'vectorReply1',
+        rank: 0.9,
+      }),
+    ])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=replies',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ type: string }>
+      searchMode: string
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    expect(body.results.length).toBeGreaterThanOrEqual(1)
+    // Only 2 DB calls: fulltext replies + vector replies (no topics)
+    expect(mockDb.execute).toHaveBeenCalledTimes(2)
+
+    await hybridApp.close()
+  })
+
+  // =========================================================================
+  // Hybrid search: RRF fusion merges overlapping results
+  // =========================================================================
+
+  it('hybrid search merges duplicate URIs via RRF fusion', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+
+    const hybridApp = await buildTestApp()
+
+    const sharedUri = `at://${TEST_DID}/forum.barazo.topic.post/shared1`
+    const topicRow = sampleTopicRow({ uri: sharedUri, rkey: 'shared1', rank: 0.8 })
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([topicRow])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics (same URI as fulltext -- should merge)
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ uri: sharedUri, rkey: 'shared1', rank: 0.7 }),
+    ])
+    // Vector replies
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=overlap&type=all',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ uri: string; rank: number }>
+      searchMode: string
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    // The same URI should appear only once (merged by RRF)
+    const uris = body.results.map((r) => r.uri)
+    expect(new Set(uris).size).toBe(uris.length)
+    // The merged item's rank should reflect combined RRF score
+    expect(body.results).toHaveLength(1)
+
+    await hybridApp.close()
+  })
+
+  // =========================================================================
+  // Hybrid search with all filters applied
+  // =========================================================================
+
+  it('hybrid search applies all filters to vector topic queries', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+
+    const hybridApp = await buildTestApp()
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics (with filters)
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ category: 'guides', author_did: 'did:plc:author1' }),
+    ])
+    // Vector replies (with filters)
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test&category=guides&author=did:plc:author1&dateFrom=2026-01-01T00:00:00Z&dateTo=2026-12-31T23:59:59Z',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ category: string | null; authorDid: string }>
+      searchMode: string
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    // 4 DB calls: fulltext topics, fulltext replies, vector topics, vector replies
+    expect(mockDb.execute).toHaveBeenCalledTimes(4)
+
+    await hybridApp.close()
+  })
+
+  it('hybrid search applies all filters to vector reply queries', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+
+    const hybridApp = await buildTestApp()
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector replies (with filters)
+    mockDb.execute.mockResolvedValueOnce([
+      sampleReplyRow({
+        author_did: 'did:plc:author2',
+        created_at: new Date('2026-06-15T10:00:00Z'),
+      }),
+    ])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test&author=did:plc:author2&dateFrom=2026-01-01T00:00:00Z&dateTo=2026-12-31T23:59:59Z',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ type: string }>
+      searchMode: string
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    expect(mockDb.execute).toHaveBeenCalledTimes(4)
+
+    await hybridApp.close()
+  })
+
+  // =========================================================================
+  // Vector search date serialization (string dates for vector results)
+  // =========================================================================
+
+  it('handles string dates from DB in vector topic results', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2])
+
+    const hybridApp = await buildTestApp()
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics with string date
+    mockDb.execute.mockResolvedValueOnce([
+      sampleTopicRow({ created_at: '2026-03-01T00:00:00.000Z' }),
+    ])
+    // Vector replies
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ createdAt: string }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.createdAt).toBe('2026-03-01T00:00:00.000Z')
+
+    await hybridApp.close()
+  })
+
+  it('handles string dates from DB in vector reply results', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2])
+
+    const hybridApp = await buildTestApp()
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector replies with string date
+    mockDb.execute.mockResolvedValueOnce([
+      sampleReplyRow({ created_at: '2026-04-01T12:00:00.000Z' }),
+    ])
+
+    const response = await hybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ createdAt: string }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.createdAt).toBe('2026-04-01T12:00:00.000Z')
+
+    await hybridApp.close()
+  })
+
+  // =========================================================================
+  // Reply date serialization (string fallback)
+  // =========================================================================
+
+  it('handles string dates from DB in fulltext reply results', async () => {
+    mockDb.execute.mockResolvedValueOnce([])
+    mockDb.execute.mockResolvedValueOnce([
+      sampleReplyRow({ created_at: '2026-05-01T08:00:00.000Z' }),
+    ])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ createdAt: string }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.createdAt).toBe('2026-05-01T08:00:00.000Z')
+  })
+
+  // =========================================================================
+  // Pagination: count queries with all filters
+  // =========================================================================
+
+  it('passes all filters to count query for topics when paginated', async () => {
+    // Use limit=1 so 2 results triggers hasMore
+    // With type=topics, only topic count query runs
+    const rows = [
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/a`,
+        rkey: 'a',
+        rank: 0.9,
+      }),
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/b`,
+        rkey: 'b',
+        rank: 0.8,
+      }),
+    ]
+
+    // Full-text topic search returns 2 rows (limit=1, fetch limit+1=2)
+    mockDb.execute.mockResolvedValueOnce(rows)
+    // Count query for topics (with category, author, dateFrom, dateTo filters)
+    mockDb.execute.mockResolvedValueOnce([{ count: '100' }])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=topics&limit=1&category=general&author=did:plc:testuser123&dateFrom=2026-01-01T00:00:00Z&dateTo=2026-12-31T23:59:59Z',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      cursor: string | null
+      total: number
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.cursor).toBeTruthy()
+    expect(body.total).toBe(100)
+    // 2 DB calls: topic search + topic count
+    expect(mockDb.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes all filters to count query for replies when paginated', async () => {
+    const rows = [
+      sampleReplyRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.reply/r1`,
+        rkey: 'r1',
+        rank: 0.9,
+      }),
+      sampleReplyRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.reply/r2`,
+        rkey: 'r2',
+        rank: 0.8,
+      }),
+    ]
+
+    // Full-text reply search returns 2 rows (limit=1, fetch limit+1=2)
+    mockDb.execute.mockResolvedValueOnce(rows)
+    // Count query for replies (with author, dateFrom, dateTo filters)
+    mockDb.execute.mockResolvedValueOnce([{ count: '50' }])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=replies&limit=1&author=did:plc:testuser123&dateFrom=2026-01-01T00:00:00Z&dateTo=2026-12-31T23:59:59Z',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      cursor: string | null
+      total: number
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.cursor).toBeTruthy()
+    expect(body.total).toBe(50)
+    // 2 DB calls: reply search + reply count
+    expect(mockDb.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs both topic and reply count queries for type=all when paginated', async () => {
+    // With type=all and limit=1, we need 2 results across topics+replies
+    const topicRows = [
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/ct1`,
+        rkey: 'ct1',
+        rank: 0.95,
+      }),
+    ]
+    const replyRows = [
+      sampleReplyRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.reply/cr1`,
+        rkey: 'cr1',
+        rank: 0.85,
+      }),
+    ]
+
+    // Full-text topic search
+    mockDb.execute.mockResolvedValueOnce(topicRows)
+    // Full-text reply search
+    mockDb.execute.mockResolvedValueOnce(replyRows)
+    // Count query for topics
+    mockDb.execute.mockResolvedValueOnce([{ count: '30' }])
+    // Count query for replies
+    mockDb.execute.mockResolvedValueOnce([{ count: '20' }])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=all&limit=1',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      cursor: string | null
+      total: number
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.cursor).toBeTruthy()
+    expect(body.total).toBe(50) // 30 + 20
+    // 4 DB calls: topic search + reply search + topic count + reply count
+    expect(mockDb.execute).toHaveBeenCalledTimes(4)
+  })
+
+  // =========================================================================
+  // Count queries with global mode (no communityDid filter)
+  // =========================================================================
+
+  it('count queries work without community filter in global mode', async () => {
+    const globalApp = Fastify({ logger: false })
+
+    globalApp.decorateRequest('user', undefined as RequestUser | undefined)
+    globalApp.decorate('db', mockDb as never)
+    globalApp.decorate('env', {
+      EMBEDDING_URL: undefined,
+      AI_EMBEDDING_DIMENSIONS: 768,
+      COMMUNITY_MODE: 'global',
+      COMMUNITY_DID: undefined,
+    } as never)
+    globalApp.decorate('authMiddleware', {
+      requireAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+      optionalAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+    } as never)
+    globalApp.decorate('cache', {} as never)
+
+    await globalApp.register(searchRoutes())
+    await globalApp.ready()
+
+    const rows = [
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/g1`,
+        rkey: 'g1',
+        rank: 0.9,
+      }),
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/g2`,
+        rkey: 'g2',
+        rank: 0.8,
+      }),
+    ]
+
+    // Full-text topic search (limit=1, returns 2)
+    mockDb.execute.mockResolvedValueOnce(rows)
+    // Full-text reply search
+    mockDb.execute.mockResolvedValueOnce([])
+    // Count query topics
+    mockDb.execute.mockResolvedValueOnce([{ count: '25' }])
+    // Count query replies
+    mockDb.execute.mockResolvedValueOnce([{ count: '10' }])
+
+    const response = await globalApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=1',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      total: number
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.total).toBe(35)
+
+    await globalApp.close()
+  })
+
+  // =========================================================================
+  // Content snippet: short content (no truncation)
+  // =========================================================================
+
+  it('does not truncate content shorter than 300 chars', async () => {
+    const shortContent = 'Short content here.'
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow({ content: shortContent })])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ content: string }>
+    }>()
+    expect(body.results[0]?.content).toBe(shortContent)
+    expect(body.results[0]?.content).not.toContain('...')
+  })
+
+  // =========================================================================
+  // Cursor with type=replies (cursor filter in reply search)
+  // =========================================================================
+
+  it('passes cursor to reply search when type=replies', async () => {
+    const cursorPayload = Buffer.from(
+      JSON.stringify({ rank: 0.4, uri: 'at://did:plc:x/forum.barazo.topic.reply/prev' })
+    ).toString('base64')
+
+    mockDb.execute.mockResolvedValueOnce([sampleReplyRow()])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/search?q=test&type=replies&cursor=${encodeURIComponent(cursorPayload)}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json<{ results: unknown[] }>().results).toHaveLength(1)
+    // Only 1 DB call: reply search (no topic search for type=replies)
+    expect(mockDb.execute).toHaveBeenCalledTimes(1)
+  })
+
+  // =========================================================================
+  // Hybrid search in global mode (no communityDid for vector search)
+  // =========================================================================
+
+  it('hybrid search runs without community filter in global mode', async () => {
+    mockIsEnabled.mockReturnValue(true)
+    mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3])
+
+    const globalHybridApp = Fastify({ logger: false })
+
+    globalHybridApp.decorateRequest('user', undefined as RequestUser | undefined)
+    globalHybridApp.decorate('db', mockDb as never)
+    globalHybridApp.decorate('env', {
+      EMBEDDING_URL: 'http://embedding:8080',
+      AI_EMBEDDING_DIMENSIONS: 768,
+      COMMUNITY_MODE: 'global',
+      COMMUNITY_DID: undefined,
+    } as never)
+    globalHybridApp.decorate('authMiddleware', {
+      requireAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+      optionalAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+    } as never)
+    globalHybridApp.decorate('cache', {} as never)
+
+    await globalHybridApp.register(searchRoutes())
+    await globalHybridApp.ready()
+
+    // Full-text topics
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    // Full-text replies
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector topics
+    mockDb.execute.mockResolvedValueOnce([])
+    // Vector replies
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await globalHybridApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      searchMode: string
+      results: unknown[]
+    }>()
+    expect(body.searchMode).toBe('hybrid')
+    expect(body.results.length).toBeGreaterThanOrEqual(1)
+
+    await globalHybridApp.close()
+  })
+
+  // =========================================================================
+  // Muted word annotation with authenticated user
+  // =========================================================================
+
+  it('annotates results with isMutedWord=true when muted words match', async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow({ content: 'This contains spam word' })])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    // Configure muted words to return a match
+    mockLoadMutedWords.mockResolvedValue(['spam'])
+    mockContentMatchesMutedWords.mockReturnValue(true)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ isMutedWord: boolean }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.isMutedWord).toBe(true)
+    expect(mockLoadMutedWords).toHaveBeenCalled()
+    expect(mockContentMatchesMutedWords).toHaveBeenCalled()
+  })
+
+  it('annotates results with isMutedWord=false when no muted words match', async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    mockLoadMutedWords.mockResolvedValue(['something-unrelated'])
+    mockContentMatchesMutedWords.mockReturnValue(false)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ isMutedWord: boolean }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.isMutedWord).toBe(false)
+  })
+
+  it('calls loadMutedWords with authenticated user DID', async () => {
+    mockDb.execute.mockResolvedValueOnce([sampleTopicRow()])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    // Simulate an authenticated user by setting request.user in the optionalAuth handler
+    const authApp = Fastify({ logger: false })
+
+    authApp.decorateRequest('user', undefined as RequestUser | undefined)
+    authApp.decorate('db', mockDb as never)
+    authApp.decorate('env', {
+      EMBEDDING_URL: undefined,
+      AI_EMBEDDING_DIMENSIONS: 768,
+      COMMUNITY_MODE: 'single',
+      COMMUNITY_DID: TEST_COMMUNITY_DID,
+    } as never)
+    authApp.decorate('authMiddleware', {
+      requireAuth: vi.fn((_req: unknown, _reply: unknown) => Promise.resolve()),
+      optionalAuth: vi.fn((req: { user: RequestUser | undefined }, _reply: unknown) => {
+        req.user = { did: 'did:plc:autheduser', handle: 'authed.test' }
+        return Promise.resolve()
+      }),
+    } as never)
+    authApp.decorate('cache', {} as never)
+
+    await authApp.register(searchRoutes())
+    await authApp.ready()
+
+    const response = await authApp.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    // loadMutedWords should be called with the authenticated user's DID
+    expect(mockLoadMutedWords).toHaveBeenCalledWith(
+      'did:plc:autheduser',
+      TEST_COMMUNITY_DID,
+      expect.anything()
+    )
+
+    await authApp.close()
+  })
+
+  // =========================================================================
+  // Fulltext-only: sort by rank descending
+  // =========================================================================
+
+  it('sorts fulltext-only results by rank descending', async () => {
+    const lowRank = sampleTopicRow({
+      uri: `at://${TEST_DID}/forum.barazo.topic.post/low`,
+      rkey: 'low',
+      rank: 0.3,
+    })
+    const highRank = sampleTopicRow({
+      uri: `at://${TEST_DID}/forum.barazo.topic.post/high`,
+      rkey: 'high',
+      rank: 0.9,
+    })
+
+    // Return in reverse order (low rank first) to verify sorting
+    mockDb.execute.mockResolvedValueOnce([lowRank, highRank])
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&type=topics',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ uri: string; rank: number }>
+    }>()
+    expect(body.results).toHaveLength(2)
+    // High rank should be first after sorting
+    expect(body.results[0]?.uri).toContain('high')
+    expect(body.results[1]?.uri).toContain('low')
+    const first = body.results[0]
+    const second = body.results[1]
+    expect(first?.rank).toBeGreaterThan(second?.rank ?? 0)
+  })
+
+  // =========================================================================
+  // Validation: limit boundaries
+  // =========================================================================
+
+  it('returns 400 for limit=0 (below minimum)', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=0',
+    })
+
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('returns 400 for limit=101 (above maximum)', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=101',
+    })
+
+    expect(response.statusCode).toBe(400)
+  })
+
+  it('returns 400 for non-numeric limit', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=abc',
+    })
+
+    expect(response.statusCode).toBe(400)
+  })
+
+  // =========================================================================
+  // Reply with null root_title
+  // =========================================================================
+
+  it('handles reply with null root_title', async () => {
+    const replyRow = sampleReplyRow({ root_title: null })
+    mockDb.execute.mockReset()
+    mockDb.execute.mockResolvedValueOnce([])
+    mockDb.execute.mockResolvedValueOnce([replyRow])
+    mockDb.execute.mockResolvedValue([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: Array<{ rootTitle: string | null }>
+    }>()
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]?.rootTitle).toBeNull()
+  })
+
+  // =========================================================================
+  // Count query with empty count row (fallback to 0)
+  // =========================================================================
+
+  it('handles empty count rows (defaults to 0)', async () => {
+    const rows = [
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/c1`,
+        rkey: 'c1',
+        rank: 0.9,
+      }),
+      sampleTopicRow({
+        uri: `at://${TEST_DID}/forum.barazo.topic.post/c2`,
+        rkey: 'c2',
+        rank: 0.8,
+      }),
+    ]
+
+    // Topic search returns 2 (limit=1 -> hasMore)
+    mockDb.execute.mockResolvedValueOnce(rows)
+    // Reply search
+    mockDb.execute.mockResolvedValueOnce([])
+    // Count query topics returns empty array
+    mockDb.execute.mockResolvedValueOnce([])
+    // Count query replies returns empty array
+    mockDb.execute.mockResolvedValueOnce([])
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/search?q=test&limit=1',
+    })
+
+    expect(response.statusCode).toBe(200)
+    const body = response.json<{
+      results: unknown[]
+      total: number
+    }>()
+    expect(body.results).toHaveLength(1)
+    // Both count queries returned empty -> total should be 0
+    expect(body.total).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- Improve overall branch coverage from 75.27% to 87.28%, clearing the 80% CI gate
- Add ~9,400 lines of new tests across 9 test files (1996 total tests)
- Achieve 100% coverage on ozone.ts and profiles.ts

## Changes
- **tests/unit/services/ozone.test.ts** — Rewritten: WebSocket lifecycle, reconnect with exponential backoff, label processing, batch spam detection, cache graceful degradation (53% → 100%)
- **tests/unit/routes/profiles.test.ts** — Added reputation PDS trust, sybil cluster penalties, age declaration, preferences CRUD, defensive guards (63% → 100%)
- **tests/unit/routes/search.test.ts** — Added hybrid search paths, cursor pagination, muted word annotation, count query filters, validation boundaries (63% → 97%)
- **tests/unit/routes/replies.test.ts** — Added onboarding gate, anti-spam branches, ozone annotations, maturity filtering, PDS/DB error re-throws (72% → 97%)
- **tests/unit/routes/topics.test.ts** — Added maturity restriction, anti-spam untrusted path, content held for moderation, ozone spam label, cross-post deletion, global mode (71% → 94%)
- **tests/unit/routes/moderation-queue.test.ts** — Added cursor pagination, queueReason filter, trust record management, word filter tests (46% → 95%)
- **tests/unit/routes/moderation.test.ts** — Added passthrough auth for handler-level guards, lock/pin/delete/ban auth branches, global mode ban propagation, report CRUD, appeal routes (72% → 90%)
- **tests/unit/routes/categories.test.ts** — Added ordering, validation boundaries, empty states, edge cases (73% → 96%)
- **tests/unit/routes/notifications.test.ts** — Improved coverage for all notification types

## Test plan
- [x] All 1996 tests pass across 102 test files
- [x] ESLint clean (0 errors)
- [x] TypeScript typecheck passes
- [x] Overall coverage: 93.86% statements, 87.28% branches, 91.98% functions, 94.09% lines
- [ ] CI passes (lint, typecheck, build, tests)