### PR TITLE
ci: add pnpm cache and frozen-lockfile to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
   typecheck:
@@ -39,11 +40,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
 
   test:
@@ -55,11 +57,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
   test-integration:
@@ -94,11 +97,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm db:migrate
         env:
           DATABASE_URL: postgresql://barazo:barazo_dev@localhost:5432/barazo
@@ -118,11 +122,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
   security:
@@ -134,11 +139,12 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
+          cache: 'pnpm'
       - name: Clone and build barazo-lexicons
         run: |
           git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
           cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - name: Security audit with retry
         run: |
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary
- Add `cache: 'pnpm'` to all 6 `actions/setup-node` steps to cache dependencies between CI runs
- Change all 6 `pnpm install` commands to `pnpm install --frozen-lockfile` to fail on lockfile drift
- Aligns barazo-api CI with barazo-web and barazo-lexicons configuration

## Test plan
- [ ] CI checks pass
- [ ] Verify pnpm cache is restored on subsequent runs (visible in setup-node step output)