### PR TITLE
fix(ozone): handle Blob data from Node.js 24 native WebSocket

### DIFF
--- a/src/services/ozone.ts
+++ b/src/services/ozone.ts
@@ -104,7 +104,8 @@ export class OzoneService {
 
   private async handleMessage(data: unknown): Promise<void> {
     try {
-      const text = typeof data === 'string' ? data : String(data)
+      const text =
+        data instanceof Blob ? await data.text() : typeof data === 'string' ? data : String(data)
       const event = JSON.parse(text) as LabelEvent
 
       if (!Array.isArray(event.labels)) return

--- a/tests/unit/services/ozone.test.ts
+++ b/tests/unit/services/ozone.test.ts
@@ -735,6 +735,28 @@ describe('OzoneService', () => {
       )
     })
 
+    it('handleMessage handles Blob data from Node.js native WebSocket', async () => {
+      const labelEvent = {
+        seq: 1,
+        labels: [
+          {
+            src: 'did:plc:labeler1',
+            uri: 'did:plc:user1',
+            val: 'spam',
+            neg: false,
+            cts: '2026-01-15T12:00:00.000Z',
+          },
+        ],
+      }
+      const blob = new Blob([JSON.stringify(labelEvent)], { type: 'application/json' })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      await (service as any).handleMessage(blob)
+
+      expect(db.insert).toHaveBeenCalled()
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+
     it('handleMessage handles non-string data by converting to string', async () => {
       const event = {
         seq: 1,


### PR DESCRIPTION
## Summary

- Convert `Blob` to text via `.text()` before `JSON.parse()` in `OzoneService.handleMessage`
- Node.js 24's `undici` WebSocket delivers binary messages as `Blob` by default; `String(blob)` produces `"[object Blob]"`, breaking JSON parsing
- Adds test covering Blob message handling

## Impact

- Stops ~1 error/sec log spam from `SyntaxError: Unexpected token 'o'`
- Ozone label events are now correctly processed instead of silently dropped

Fixes barazo-forum/barazo-workspace#51

## Test plan

- [x] New unit test: `handleMessage handles Blob data from Node.js native WebSocket`
- [x] All 49 existing OzoneService tests pass
- [x] Typecheck clean
- [x] Lint clean