### PR TITLE
feat(db): auto-migrate on API startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ COPY --from=builder /app/deploy/ ./
 # Copy compiled output
 COPY --from=builder /workspace/barazo-api/dist/ ./dist/
 
+# Copy Drizzle migration files (applied on startup)
+COPY --from=builder /workspace/barazo-api/drizzle/ ./drizzle/
+
 # Create plugins directory for runtime plugin loading
 RUN mkdir -p /app/plugins && chown barazo:nodejs /app/plugins
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,7 +14,7 @@ import type { Env } from './config/env.js'
 import { getCommunityDid } from './config/env.js'
 import { createSingleResolver, registerCommunityResolver } from './middleware/community-resolver.js'
 import type { CommunityResolver } from './middleware/community-resolver.js'
-import { createDb } from './db/index.js'
+import { createDb, runMigrations } from './db/index.js'
 import { createCache } from './cache/index.js'
 import { FirehoseService } from './firehose/service.js'
 import { createOAuthClient } from './auth/oauth-client.js'
@@ -106,7 +106,11 @@ export async function buildApp(env: Env) {
     trustProxy: true,
   })
 
-  // Database
+  // Database -- run migrations before creating the main connection pool
+  const migrationsFolder = new URL('../drizzle', import.meta.url).pathname
+  await runMigrations(env.DATABASE_URL, migrationsFolder)
+  app.log.info('Database migrations applied')
+
   const { db, client: dbClient } = createDb(env.DATABASE_URL)
   app.decorate('db', db)
   app.decorate('env', env)

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import postgres from 'postgres'
 import * as schema from './schema/index.js'
 
@@ -12,6 +13,17 @@ export function createDb(databaseUrl: string) {
   const db = drizzle(client, { schema })
 
   return { db, client }
+}
+
+/**
+ * Run pending Drizzle migrations against the database.
+ * Idempotent -- already-applied migrations are skipped.
+ */
+export async function runMigrations(databaseUrl: string, migrationsFolder: string): Promise<void> {
+  const migrationClient = postgres(databaseUrl, { max: 1 })
+  const migrationDb = drizzle(migrationClient)
+  await migrate(migrationDb, { migrationsFolder })
+  await migrationClient.end()
 }
 
 export type Database = ReturnType<typeof createDb>['db']

--- a/tests/unit/routes/health.test.ts
+++ b/tests/unit/routes/health.test.ts
@@ -6,7 +6,9 @@ import type { FastifyInstance } from 'fastify'
 const mockExecute = vi.fn().mockResolvedValue([{ '?column?': 1 }])
 const mockDb = {
   execute: mockExecute,
-  select: vi.fn().mockReturnValue({ from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) }),
+  select: vi
+    .fn()
+    .mockReturnValue({ from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) }),
   insert: vi.fn(),
   update: vi.fn(),
   delete: vi.fn(),
@@ -18,6 +20,7 @@ const mockClient = {
 }
 vi.mock('../../../src/db/index.js', () => ({
   createDb: () => ({ db: mockDb, client: mockClient }),
+  runMigrations: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Mock cache to avoid real Valkey connection


### PR DESCRIPTION
## Summary
- Adds `runMigrations()` to `src/db/index.ts` using Drizzle's built-in migrator — idempotent, skips already-applied migrations
- Calls it in `src/app.ts` before the connection pool is created, using a dedicated single-connection client
- Copies `drizzle/` migration folder into the Docker production image
- Mocks `runMigrations` in the health test to avoid real DB connections

Fixes the root cause of the staging 500 errors where `cross_post_scopes_granted`, `banner_url`, `bio`, and other columns were missing — the database was originally built with `drizzle-kit push` (no migration tracking), so new migrations were never applied.

Any fresh deployment now gets a fully up-to-date schema automatically.

## Test plan
- [x] All 105 test files pass (2050 tests)
- [x] TypeCheck passes
- [ ] CI passes
- [ ] Deploy to staging and verify no migration errors in logs
- [ ] Verify `__drizzle_migrations` table is created on staging