### PR TITLE
fix(auth): upsert user row on OAuth callback

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -9,6 +9,7 @@ import {
   FALLBACK_SCOPE,
   hasCrossPostScopes,
 } from '../auth/scopes.js'
+import { users } from '../db/schema/users.js'
 import { userPreferences } from '../db/schema/user-preferences.js'
 
 // ---------------------------------------------------------------------------
@@ -130,6 +131,15 @@ export function authRoutes(oauthClient: NodeOAuthClient): FastifyPluginCallback 
           // Resolve handle from DID via AT Protocol identity layer
           // (PLC directory lookup with Valkey cache + DB fallback)
           const handle = await handleResolver.resolve(did)
+
+          // Ensure user row exists (first login creates, subsequent logins update handle)
+          await app.db
+            .insert(users)
+            .values({ did, handle })
+            .onConflictDoUpdate({
+              target: users.did,
+              set: { handle, lastActiveAt: new Date() },
+            })
 
           const session = await sessionService.createSession(did, handle)
 

--- a/tests/unit/routes/auth.test.ts
+++ b/tests/unit/routes/auth.test.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from 'fastify'
 import type { SessionService, SessionWithToken, Session } from '../../../src/auth/session.js'
 import type { Env } from '../../../src/config/env.js'
 import { authRoutes } from '../../../src/routes/auth.js'
+import { users } from '../../../src/db/schema/users.js'
 import type { HandleResolver } from '../../../src/lib/handle-resolver.js'
 import {
   BARAZO_BASE_SCOPES,
@@ -312,6 +313,32 @@ describe('auth routes', () => {
       expect(response.statusCode).toBe(400)
       const body = response.json<{ error: string }>()
       expect(body.error).toBe('Invalid callback parameters')
+    })
+
+    it('upserts user row in database on successful callback', async () => {
+      const mockSession = makeMockSessionWithToken()
+      const mockOAuthSession = { did: TEST_DID }
+
+      callbackFn.mockResolvedValueOnce({
+        session: mockOAuthSession,
+        state: 'some-state',
+      })
+      resolveFn.mockResolvedValueOnce(TEST_HANDLE)
+      createSessionFn.mockResolvedValueOnce(mockSession)
+
+      await app.inject({
+        method: 'GET',
+        url: '/api/auth/callback?iss=https://pds.example.com&code=test-code&state=test-state',
+      })
+
+      // Verify user row was upserted (insert with onConflictDoUpdate)
+      expect(dbInsertFn).toHaveBeenCalledWith(users)
+      expect(dbValuesFn).toHaveBeenCalledWith(
+        expect.objectContaining({ did: TEST_DID, handle: TEST_HANDLE })
+      )
+      expect(dbOnConflictDoUpdateFn).toHaveBeenCalledWith(
+        expect.objectContaining({ target: users.did })
+      )
     })
 
     it('redirects to frontend with error when OAuth client throws', async () => {


### PR DESCRIPTION
## Summary

- The auth callback relied on `profileSync.syncProfile()` to create the user row, but that method only does an `UPDATE` -- silently no-oping when no row exists (first-time login)
- Added a user upsert (`INSERT ... ON CONFLICT DO UPDATE`) in the OAuth callback, between handle resolution and session creation
- First login creates the user row with DID + handle; subsequent logins update the handle and `lastActiveAt`
- Profile sync continues to run fire-and-forget after the upsert, updating display name, avatar, banner, and bio

## Test plan

- [x] New test: `upserts user row in database on successful callback`
- [x] All 2051 existing tests pass
- [x] TypeScript strict mode passes
- [ ] Deploy to staging, log out, log back in, verify `/u/{handle}` shows profile