### PR TITLE
fix(api): align community preferences routes with frontend client

### DIFF
--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -16,6 +16,7 @@ import { votes } from '../db/schema/votes.js'
 import { notifications } from '../db/schema/notifications.js'
 import { reports } from '../db/schema/reports.js'
 import { userPreferences, userCommunityPreferences } from '../db/schema/user-preferences.js'
+import { communitySettings } from '../db/schema/community-settings.js'
 import { computeClusterDiversityFactor } from '../services/cluster-diversity.js'
 import { sybilClusterMembers } from '../db/schema/sybil-cluster-members.js'
 import { sybilClusters } from '../db/schema/sybil-clusters.js'
@@ -183,10 +184,11 @@ function defaultCommunityPreferences(communityDid: string) {
  * - GET    /api/users/:handle                              -- Public profile
  * - GET    /api/users/:handle/reputation                   -- Reputation score
  * - POST   /api/users/me/age-declaration                   -- Declare age
- * - GET    /api/users/me/preferences                       -- Global preferences
- * - PUT    /api/users/me/preferences                       -- Update global preferences
- * - GET    /api/users/me/communities/:communityId/preferences -- Per-community prefs
- * - PUT    /api/users/me/communities/:communityId/preferences -- Update per-community prefs
+ * - GET    /api/users/me/preferences                              -- Global preferences
+ * - PUT    /api/users/me/preferences                              -- Update global preferences
+ * - GET    /api/users/me/preferences/communities                  -- List community overrides
+ * - GET    /api/users/me/preferences/communities/:communityDid    -- Per-community prefs
+ * - PUT    /api/users/me/preferences/communities/:communityDid    -- Update per-community prefs
  * - DELETE /api/users/me                                   -- GDPR Art. 17 purge
  */
 export function profileRoutes(): FastifyPluginCallback {
@@ -840,11 +842,85 @@ export function profileRoutes(): FastifyPluginCallback {
     )
 
     // -------------------------------------------------------------------
-    // GET /api/users/me/communities/:communityId/preferences (auth required)
+    // GET /api/users/me/preferences/communities (auth required) -- list
     // -------------------------------------------------------------------
 
     app.get(
-      '/api/users/me/communities/:communityId/preferences',
+      '/api/users/me/preferences/communities',
+      {
+        preHandler: [authMiddleware.requireAuth],
+        schema: {
+          tags: ['Profiles'],
+          summary: 'List all per-community user preference overrides',
+          security: [{ bearerAuth: [] }],
+          response: {
+            200: {
+              type: 'object' as const,
+              properties: {
+                communities: {
+                  type: 'array' as const,
+                  items: {
+                    type: 'object' as const,
+                    properties: {
+                      communityDid: { type: 'string' as const },
+                      communityName: { type: 'string' as const },
+                      maturityLevel: { type: 'string' as const },
+                      mutedWords: {
+                        type: 'array' as const,
+                        items: { type: 'string' as const },
+                      },
+                      blockedDids: {
+                        type: 'array' as const,
+                        items: { type: 'string' as const },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            401: errorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const requestUser = request.user
+        if (!requestUser) {
+          return reply.status(401).send({ error: 'Authentication required' })
+        }
+
+        const rows = await db
+          .select({
+            communityDid: userCommunityPreferences.communityDid,
+            maturityOverride: userCommunityPreferences.maturityOverride,
+            mutedWords: userCommunityPreferences.mutedWords,
+            blockedDids: userCommunityPreferences.blockedDids,
+            communityName: communitySettings.communityName,
+          })
+          .from(userCommunityPreferences)
+          .leftJoin(
+            communitySettings,
+            eq(userCommunityPreferences.communityDid, communitySettings.communityDid)
+          )
+          .where(eq(userCommunityPreferences.did, requestUser.did))
+
+        const communities = rows.map((row) => ({
+          communityDid: row.communityDid,
+          communityName: row.communityName ?? row.communityDid,
+          maturityLevel: row.maturityOverride ?? 'inherit',
+          mutedWords: row.mutedWords ?? [],
+          blockedDids: row.blockedDids ?? [],
+        }))
+
+        return reply.status(200).send({ communities })
+      }
+    )
+
+    // -------------------------------------------------------------------
+    // GET /api/users/me/preferences/communities/:communityDid (auth required)
+    // -------------------------------------------------------------------
+
+    app.get(
+      '/api/users/me/preferences/communities/:communityDid',
       {
         preHandler: [authMiddleware.requireAuth],
         schema: {
@@ -853,9 +929,9 @@ export function profileRoutes(): FastifyPluginCallback {
           security: [{ bearerAuth: [] }],
           params: {
             type: 'object',
-            required: ['communityId'],
+            required: ['communityDid'],
             properties: {
-              communityId: { type: 'string' },
+              communityDid: { type: 'string' },
             },
           },
           response: {
@@ -870,7 +946,7 @@ export function profileRoutes(): FastifyPluginCallback {
           return reply.status(401).send({ error: 'Authentication required' })
         }
 
-        const { communityId } = request.params as { communityId: string }
+        const { communityDid } = request.params as { communityDid: string }
 
         const rows = await db
           .select()
@@ -878,13 +954,13 @@ export function profileRoutes(): FastifyPluginCallback {
           .where(
             and(
               eq(userCommunityPreferences.did, requestUser.did),
-              eq(userCommunityPreferences.communityDid, communityId)
+              eq(userCommunityPreferences.communityDid, communityDid)
             )
           )
 
         const prefs = rows[0]
         if (!prefs) {
-          return reply.status(200).send(defaultCommunityPreferences(communityId))
+          return reply.status(200).send(defaultCommunityPreferences(communityDid))
         }
 
         return reply.status(200).send({
@@ -900,11 +976,11 @@ export function profileRoutes(): FastifyPluginCallback {
     )
 
     // -------------------------------------------------------------------
-    // PUT /api/users/me/communities/:communityId/preferences (auth required)
+    // PUT /api/users/me/preferences/communities/:communityDid (auth required)
     // -------------------------------------------------------------------
 
     app.put(
-      '/api/users/me/communities/:communityId/preferences',
+      '/api/users/me/preferences/communities/:communityDid',
       {
         preHandler: [authMiddleware.requireAuth],
         schema: {
@@ -913,9 +989,9 @@ export function profileRoutes(): FastifyPluginCallback {
           security: [{ bearerAuth: [] }],
           params: {
             type: 'object',
-            required: ['communityId'],
+            required: ['communityDid'],
             properties: {
-              communityId: { type: 'string' },
+              communityDid: { type: 'string' },
             },
           },
           body: {
@@ -961,7 +1037,7 @@ export function profileRoutes(): FastifyPluginCallback {
           return reply.status(401).send({ error: 'Authentication required' })
         }
 
-        const { communityId } = request.params as { communityId: string }
+        const { communityDid } = request.params as { communityDid: string }
 
         const parsed = communityPreferencesSchema.safeParse(request.body)
         if (!parsed.success) {
@@ -992,7 +1068,7 @@ export function profileRoutes(): FastifyPluginCallback {
           .insert(userCommunityPreferences)
           .values({
             did: requestUser.did,
-            communityDid: communityId,
+            communityDid,
             ...parsed.data,
             updatedAt: now,
           })
@@ -1008,13 +1084,13 @@ export function profileRoutes(): FastifyPluginCallback {
           .where(
             and(
               eq(userCommunityPreferences.did, requestUser.did),
-              eq(userCommunityPreferences.communityDid, communityId)
+              eq(userCommunityPreferences.communityDid, communityDid)
             )
           )
 
         const prefs = rows[0]
         if (!prefs) {
-          return reply.status(200).send(defaultCommunityPreferences(communityId))
+          return reply.status(200).send(defaultCommunityPreferences(communityDid))
         }
 
         return reply.status(200).send({

--- a/tests/unit/routes/profiles.test.ts
+++ b/tests/unit/routes/profiles.test.ts
@@ -1805,10 +1805,140 @@ describe('profile routes', () => {
   })
 
   // =========================================================================
-  // GET /api/users/me/communities/:communityId/preferences
+  // GET /api/users/me/preferences/communities (list)
   // =========================================================================
 
-  describe('GET /api/users/me/communities/:communityId/preferences', () => {
+  describe('GET /api/users/me/preferences/communities', () => {
+    let app: FastifyInstance
+
+    beforeAll(async () => {
+      app = await buildTestApp(testUser())
+    })
+
+    afterAll(async () => {
+      await app.close()
+    })
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+      resetAllDbMocks()
+    })
+
+    it('returns empty list when user has no community overrides', async () => {
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences/communities',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ communities: unknown[] }>()
+      expect(body.communities).toEqual([])
+    })
+
+    it('returns community overrides with mapped field names', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        {
+          communityDid: COMMUNITY_DID,
+          maturityOverride: 'mature',
+          mutedWords: ['spoiler'],
+          blockedDids: ['did:plc:blocked1'],
+          communityName: 'Test Community',
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences/communities',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        communities: {
+          communityDid: string
+          communityName: string
+          maturityLevel: string
+          mutedWords: string[]
+          blockedDids: string[]
+        }[]
+      }>()
+      expect(body.communities).toHaveLength(1)
+      expect(body.communities[0].communityDid).toBe(COMMUNITY_DID)
+      expect(body.communities[0].communityName).toBe('Test Community')
+      expect(body.communities[0].maturityLevel).toBe('mature')
+      expect(body.communities[0].mutedWords).toEqual(['spoiler'])
+      expect(body.communities[0].blockedDids).toEqual(['did:plc:blocked1'])
+    })
+
+    it('maps null maturityOverride to "inherit"', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        {
+          communityDid: COMMUNITY_DID,
+          maturityOverride: null,
+          mutedWords: null,
+          blockedDids: null,
+          communityName: 'Test Community',
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences/communities',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        communities: { maturityLevel: string; mutedWords: string[]; blockedDids: string[] }[]
+      }>()
+      expect(body.communities[0].maturityLevel).toBe('inherit')
+      expect(body.communities[0].mutedWords).toEqual([])
+      expect(body.communities[0].blockedDids).toEqual([])
+    })
+
+    it('falls back to communityDid when communityName is null', async () => {
+      selectChain.where.mockResolvedValueOnce([
+        {
+          communityDid: COMMUNITY_DID,
+          maturityOverride: null,
+          mutedWords: null,
+          blockedDids: null,
+          communityName: null,
+        },
+      ])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences/communities',
+        headers: { authorization: 'Bearer test-token' },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ communities: { communityName: string }[] }>()
+      expect(body.communities[0].communityName).toBe(COMMUNITY_DID)
+    })
+
+    it('returns 401 when not authenticated', async () => {
+      const noAuthApp = await buildTestApp(undefined)
+
+      const response = await noAuthApp.inject({
+        method: 'GET',
+        url: '/api/users/me/preferences/communities',
+      })
+
+      expect(response.statusCode).toBe(401)
+      await noAuthApp.close()
+    })
+  })
+
+  // =========================================================================
+  // GET /api/users/me/preferences/communities/:communityDid
+  // =========================================================================
+
+  describe('GET /api/users/me/preferences/communities/:communityDid', () => {
     let app: FastifyInstance
 
     beforeAll(async () => {
@@ -1839,7 +1969,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
       })
 
@@ -1859,7 +1989,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
       })
 
@@ -1894,7 +2024,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
       })
 
@@ -1939,7 +2069,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
       })
 
@@ -1963,7 +2093,7 @@ describe('profile routes', () => {
 
       const response = await noAuthApp.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
       })
 
       expect(response.statusCode).toBe(401)
@@ -1972,10 +2102,10 @@ describe('profile routes', () => {
   })
 
   // =========================================================================
-  // PUT /api/users/me/communities/:communityId/preferences
+  // PUT /api/users/me/preferences/communities/:communityDid
   // =========================================================================
 
-  describe('PUT /api/users/me/communities/:communityId/preferences', () => {
+  describe('PUT /api/users/me/preferences/communities/:communityDid', () => {
     let app: FastifyInstance
 
     beforeAll(async () => {
@@ -2002,7 +2132,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: {
           maturityOverride: 'sfw',
@@ -2027,7 +2157,7 @@ describe('profile routes', () => {
 
       const response = await noAuthApp.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         payload: { maturityOverride: 'sfw' },
       })
 
@@ -2038,7 +2168,7 @@ describe('profile routes', () => {
     it('returns 400 for invalid maturityOverride', async () => {
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { maturityOverride: 'adult' },
       })
@@ -2052,7 +2182,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { maturityOverride: 'sfw' },
       })
@@ -2079,7 +2209,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { maturityOverride: 'mature' },
       })
@@ -2094,7 +2224,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { mutedWords: ['spam'] },
       })
@@ -2111,7 +2241,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { blockedDids: ['did:plc:blocked1'] },
       })
@@ -2128,7 +2258,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { mutedDids: ['did:plc:muted1'] },
       })
@@ -2151,7 +2281,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { notificationPrefs: notifPrefs },
       })
@@ -2187,7 +2317,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: {
           maturityOverride: 'mature',
@@ -2223,7 +2353,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: {},
       })
@@ -2238,7 +2368,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { maturityOverride: null },
       })
@@ -2253,7 +2383,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { mutedWords: null },
       })
@@ -2276,7 +2406,7 @@ describe('profile routes', () => {
 
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: {},
       })
@@ -2300,7 +2430,7 @@ describe('profile routes', () => {
       // Passes Fastify JSON schema but fails Zod (.min(1) on string items)
       const response = await app.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         headers: { authorization: 'Bearer test-token' },
         payload: { mutedWords: [''] },
       })
@@ -2430,10 +2560,10 @@ describe('profile routes', () => {
       expect(body.error).toBe('Authentication required')
     })
 
-    it('GET /api/users/me/communities/:communityId/preferences returns 401 when request.user is undefined', async () => {
+    it('GET /api/users/me/preferences/communities/:communityDid returns 401 when request.user is undefined', async () => {
       const response = await passthroughApp.inject({
         method: 'GET',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
       })
 
       expect(response.statusCode).toBe(401)
@@ -2441,10 +2571,10 @@ describe('profile routes', () => {
       expect(body.error).toBe('Authentication required')
     })
 
-    it('PUT /api/users/me/communities/:communityId/preferences returns 401 when request.user is undefined', async () => {
+    it('PUT /api/users/me/preferences/communities/:communityDid returns 401 when request.user is undefined', async () => {
       const response = await passthroughApp.inject({
         method: 'PUT',
-        url: `/api/users/me/communities/${COMMUNITY_DID}/preferences`,
+        url: `/api/users/me/preferences/communities/${COMMUNITY_DID}`,
         payload: { maturityOverride: 'sfw' },
       })
 


### PR DESCRIPTION
## Summary
- Remapped per-community preference routes from `/api/users/me/communities/:communityId/preferences` to `/api/users/me/preferences/communities/:communityDid` to match the frontend API client
- Added missing `GET /api/users/me/preferences/communities` list endpoint that returns all community preference overrides for the authenticated user, with a `communitySettings` join for community names and field mapping (`maturityOverride` null → `"inherit"`, null arrays → `[]`)
- The settings page was showing "Failed to load preferences" because the frontend's `getCommunityPreferences()` call hit a 404, causing the entire `Promise.all` to reject

Fixes barazo-forum/barazo-workspace#107

## Test plan
- [x] All 2078 API tests pass (89 in profiles.test.ts, including 5 new tests for the list endpoint)
- [x] All 696 frontend tests pass (mock handlers already use the correct URLs)
- [ ] Deploy to staging and verify `/settings/` page loads without "Failed to load preferences" error
- [ ] Verify saving community preference overrides works end-to-end