### PR TITLE
ci: dispatch lockfile sync to workspace on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,3 +24,10 @@ jobs:
               "api_ref": "${{ github.sha }}",
               "web_ref": "main"
             }
+
+      - name: Sync workspace lockfile
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.DEPLOY_PAT }}
+          repository: barazo-forum/barazo-workspace
+          event-type: sync-lockfile


### PR DESCRIPTION
## Summary
- Adds a `sync-lockfile` dispatch to barazo-workspace on every push to main
- Ensures dependency changes in barazo-api are reflected in the workspace lockfile immediately

## Context
Companion to barazo-forum/barazo-workspace PR (fix/sync-lockfile-pino). When a merge to main changes `package.json`, the deploy and sync run in parallel. If the deploy fails due to lockfile drift, the sync fixes it and triggers a retry.

## Changes
- `.github/workflows/deploy-staging.yml`: adds `sync-lockfile` dispatch step using existing `DEPLOY_PAT`

## Test plan
- [ ] CI passes
- [ ] After merge, verify sync-lockfile workflow triggers in barazo-workspace