### PR TITLE
feat(auth): include user role in session and me responses

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -261,9 +261,9 @@ export function authRoutes(oauthClient: NodeOAuthClient): FastifyPluginCallback 
           maxAge: sessionTtl,
         })
 
-        // Fetch profile data (displayName, avatarUrl) from users table
+        // Fetch profile data (displayName, avatarUrl, role) from users table
         const userRows = await app.db
-          .select({ displayName: users.displayName, avatarUrl: users.avatarUrl })
+          .select({ displayName: users.displayName, avatarUrl: users.avatarUrl, role: users.role })
           .from(users)
           .where(eq(users.did, session.did))
 
@@ -280,6 +280,7 @@ export function authRoutes(oauthClient: NodeOAuthClient): FastifyPluginCallback 
           handle: session.handle,
           displayName: userRows[0]?.displayName ?? null,
           avatarUrl: userRows[0]?.avatarUrl ?? null,
+          role: userRows[0]?.role ?? 'user',
           crossPostScopesGranted: prefRows[0]?.crossPostScopesGranted ?? false,
         })
       } catch (err: unknown) {
@@ -329,9 +330,9 @@ export function authRoutes(oauthClient: NodeOAuthClient): FastifyPluginCallback 
           return await reply.status(401).send({ error: 'Invalid or expired token' })
         }
 
-        // Fetch profile data (displayName, avatarUrl) from users table
+        // Fetch profile data (displayName, avatarUrl, role) from users table
         const meUserRows = await app.db
-          .select({ displayName: users.displayName, avatarUrl: users.avatarUrl })
+          .select({ displayName: users.displayName, avatarUrl: users.avatarUrl, role: users.role })
           .from(users)
           .where(eq(users.did, session.did))
 
@@ -346,6 +347,7 @@ export function authRoutes(oauthClient: NodeOAuthClient): FastifyPluginCallback 
           handle: session.handle,
           displayName: meUserRows[0]?.displayName ?? null,
           avatarUrl: meUserRows[0]?.avatarUrl ?? null,
+          role: meUserRows[0]?.role ?? 'user',
           crossPostScopesGranted: mePrefRows[0]?.crossPostScopesGranted ?? false,
         })
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Add `role` field to the user data query in `/api/auth/refresh` and `/api/auth/me` endpoints
- Returns the user's role (`user`, `moderator`, or `admin`) so the frontend can show role-appropriate UI

## Changes
- `src/routes/auth.ts` — Added `role: users.role` to the Drizzle select query and included `role` in both endpoint responses (defaults to `'user'` if not found)

## Test plan
- [ ] CI passes (lint, typecheck, build, tests)
- [ ] Verify refresh response includes `role` field
- [ ] Companion PR: barazo-forum/barazo-web (admin panel menu)