### PR TITLE
feat(replies): serialize deletion flags and include tombstones in response

### DIFF
--- a/src/routes/replies.ts
+++ b/src/routes/replies.ts
@@ -80,6 +80,8 @@ const replyJsonSchema = {
     cid: { type: 'string' as const },
     depth: { type: 'integer' as const },
     reactionCount: { type: 'integer' as const },
+    isAuthorDeleted: { type: 'boolean' as const },
+    isModDeleted: { type: 'boolean' as const },
     isMuted: { type: 'boolean' as const },
     isMutedWord: { type: 'boolean' as const },
     ozoneLabel: { type: ['string', 'null'] as const },
@@ -125,6 +127,7 @@ function serializeReply(row: typeof replies.$inferSelect) {
     depth,
     reactionCount: row.reactionCount,
     isAuthorDeleted: row.isAuthorDeleted,
+    isModDeleted: row.isModDeleted,
     createdAt: row.createdAt.toISOString(),
     indexedAt: row.indexedAt.toISOString(),
   }
@@ -589,7 +592,6 @@ export function replyRoutes(): FastifyPluginCallback {
         const conditions = [
           eq(replies.rootUri, decodedTopicUri),
           eq(replies.moderationStatus, 'approved'),
-          eq(replies.isModDeleted, false),
         ]
 
         // Exclude replies by blocked authors

--- a/tests/unit/routes/replies.test.ts
+++ b/tests/unit/routes/replies.test.ts
@@ -2213,6 +2213,54 @@ describe('reply routes', () => {
       expect(body.replies).toHaveLength(1)
       expect(body.replies[0]?.content).toBe('[Removed by moderator]')
     })
+
+    it('includes isModDeleted in serialized response', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const modDeletedReply = sampleReplyRow({
+        isModDeleted: true,
+        isAuthorDeleted: false,
+      })
+      selectChain.limit.mockResolvedValueOnce([modDeletedReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ isAuthorDeleted: boolean; isModDeleted: boolean }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.isModDeleted).toBe(true)
+      expect(body.replies[0]?.isAuthorDeleted).toBe(false)
+    })
+
+    it('includes isAuthorDeleted and isModDeleted as false for normal replies', async () => {
+      selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
+
+      const normalReply = sampleReplyRow({
+        isAuthorDeleted: false,
+        isModDeleted: false,
+      })
+      selectChain.limit.mockResolvedValueOnce([normalReply])
+
+      const encodedTopicUri = encodeURIComponent(TEST_TOPIC_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedTopicUri}/replies`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        replies: Array<{ isAuthorDeleted: boolean; isModDeleted: boolean }>
+      }>()
+      expect(body.replies).toHaveLength(1)
+      expect(body.replies[0]?.isModDeleted).toBe(false)
+      expect(body.replies[0]?.isAuthorDeleted).toBe(false)
+    })
   })
 
   describe('PUT /api/replies/:uri (error branches)', () => {


### PR DESCRIPTION
## Summary
- Add `isAuthorDeleted` and `isModDeleted` to the Fastify reply JSON schema so they pass through serialization
- Remove the `eq(replies.isModDeleted, false)` query filter so mod-deleted replies appear in thread responses as tombstone placeholders (content already replaced with `[Removed by moderator]` by the serializer)

## Context
The frontend needs these flags to render distinct tombstone placeholders for author-deleted vs. moderator-deleted replies. Previously `isAuthorDeleted` was serialized but stripped by Fastify's schema, and mod-deleted replies were filtered out entirely.

## Test plan
- [x] New test: `isModDeleted` included in serialized mod-deleted reply response
- [x] New test: both flags `false` for normal replies
- [x] All 85 existing reply route tests pass
- [x] Full API test suite (2087 tests) passes

Fixes barazo-forum/barazo-workspace#62