### PR TITLE
fix(api): expose isModDeleted in topic and reply serializers

### DIFF
--- a/src/routes/replies.ts
+++ b/src/routes/replies.ts
@@ -106,7 +106,7 @@ function serializeReply(row: typeof replies.$inferSelect) {
   const placeholderContent = row.isModDeleted
     ? '[Removed by moderator]'
     : row.isAuthorDeleted
-      ? ''
+      ? '[Deleted by author]'
       : row.content
 
   return {
@@ -125,6 +125,7 @@ function serializeReply(row: typeof replies.$inferSelect) {
     depth,
     reactionCount: row.reactionCount,
     isAuthorDeleted: row.isAuthorDeleted,
+    isModDeleted: row.isModDeleted,
     createdAt: row.createdAt.toISOString(),
     indexedAt: row.indexedAt.toISOString(),
   }

--- a/src/routes/topics.ts
+++ b/src/routes/topics.ts
@@ -100,13 +100,19 @@ const topicJsonSchema = {
  * @param categoryMaturityRating - The maturity rating inherited from the topic's category.
  */
 function serializeTopic(row: typeof topics.$inferSelect, categoryMaturityRating: string = 'safe') {
+  const isDeleted = row.isAuthorDeleted || row.isModDeleted
+  const placeholderTitle = row.isModDeleted
+    ? '[Removed by moderator]'
+    : row.isAuthorDeleted
+      ? '[Deleted by author]'
+      : row.title
   return {
     uri: row.uri,
     rkey: row.rkey,
     authorDid: row.authorDid,
-    title: row.isAuthorDeleted ? '[Deleted by author]' : row.title,
-    content: row.isAuthorDeleted ? '' : row.content,
-    contentFormat: row.isAuthorDeleted ? null : (row.contentFormat ?? null),
+    title: placeholderTitle,
+    content: isDeleted ? '' : row.content,
+    contentFormat: isDeleted ? null : (row.contentFormat ?? null),
     category: row.category,
     tags: row.tags ?? null,
     labels: row.labels ?? null,
@@ -115,6 +121,7 @@ function serializeTopic(row: typeof topics.$inferSelect, categoryMaturityRating:
     replyCount: row.replyCount,
     reactionCount: row.reactionCount,
     isAuthorDeleted: row.isAuthorDeleted,
+    isModDeleted: row.isModDeleted,
     categoryMaturityRating,
     lastActivityAt: row.lastActivityAt.toISOString(),
     createdAt: row.createdAt.toISOString(),

--- a/tests/unit/routes/replies.test.ts
+++ b/tests/unit/routes/replies.test.ts
@@ -2090,7 +2090,7 @@ describe('reply routes', () => {
       resetAllDbMocks()
     })
 
-    it('returns empty content for author-deleted replies', async () => {
+    it('returns placeholder content for author-deleted replies', async () => {
       selectChain.where.mockResolvedValueOnce([sampleTopicRow()])
 
       const authorDeletedReply = sampleReplyRow({
@@ -2111,8 +2111,8 @@ describe('reply routes', () => {
         replies: Array<{ content: string; contentFormat: string | null }>
       }>()
       expect(body.replies).toHaveLength(1)
-      // Author-deleted replies return empty content
-      expect(body.replies[0]?.content).toBe('')
+      // Author-deleted replies return placeholder content
+      expect(body.replies[0]?.content).toBe('[Deleted by author]')
       expect(body.replies[0]?.contentFormat).toBeNull()
     })
 


### PR DESCRIPTION
## Summary

- Add `isModDeleted` to the response object in both `serializeTopic()` and `serializeReply()` — previously only `isAuthorDeleted` was exposed, making it impossible for the frontend to distinguish deletion types
- Change the author-deleted reply placeholder from `''` (empty string) to `'[Deleted by author]'` for consistency with the topic serializer
- Topics serializer now uses a unified `isDeleted` check for both deletion types when redacting content

## Test plan

- [x] `tests/unit/routes/replies.test.ts` — updated assertion for author-deleted placeholder (308 tests pass)
- [x] `tests/unit/routes/topics.test.ts` — existing assertions still pass
- [x] `tests/unit/routes/moderation.test.ts` — existing assertions still pass
- [ ] Verify on staging after deploy: tombstoned reply on `/t/community-guidelines-draft/` should show `[Deleted by author]` instead of empty card

Fixes barazo-forum/barazo-workspace#62
Fixes barazo-forum/barazo-workspace#63