### PR TITLE
fix(admin): accept null for nullable settings fields

### DIFF
--- a/src/routes/admin-settings.ts
+++ b/src/routes/admin-settings.ts
@@ -217,14 +217,14 @@ export function adminSettingsRoutes(): FastifyPluginCallback {
                 items: { type: 'string', minLength: 1, maxLength: 30 },
                 minItems: 1,
               },
-              communityDescription: { type: 'string', maxLength: 500 },
-              communityLogoUrl: { type: 'string', format: 'uri' },
+              communityDescription: { type: ['string', 'null'], maxLength: 500 },
+              communityLogoUrl: { type: ['string', 'null'], format: 'uri' },
               primaryColor: {
-                type: 'string',
+                type: ['string', 'null'],
                 pattern: '^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$',
               },
               accentColor: {
-                type: 'string',
+                type: ['string', 'null'],
                 pattern: '^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$',
               },
               jurisdictionCountry: { type: ['string', 'null'] },

--- a/src/validation/admin-settings.ts
+++ b/src/validation/admin-settings.ts
@@ -23,15 +23,18 @@ export const updateSettingsSchema = z.object({
     .string()
     .trim()
     .max(500, 'Community description must be at most 500 characters')
+    .nullable()
     .optional(),
-  communityLogoUrl: z.url('Community logo must be a valid URL').optional(),
+  communityLogoUrl: z.url('Community logo must be a valid URL').nullable().optional(),
   primaryColor: z
     .string()
     .regex(hexColorPattern, 'Primary color must be a valid hex color (e.g., #ff0000)')
+    .nullable()
     .optional(),
   accentColor: z
     .string()
     .regex(hexColorPattern, 'Accent color must be a valid hex color (e.g., #00ff00)')
+    .nullable()
     .optional(),
   jurisdictionCountry: z
     .string()


### PR DESCRIPTION
## Summary

- PUT `/api/admin/settings` rejected `null` for `communityDescription`, `communityLogoUrl`, `primaryColor`, and `accentColor` — despite the GET response returning `null` for these fields when unset
- The frontend round-trips the full settings object (including nulls), causing Fastify's AJV validator to reject the request with a 400 before the route handler runs
- Added `null` as an accepted type in both the Fastify JSON Schema and Zod validation, matching the existing pattern used by `jurisdictionCountry`

## Test plan

- [x] All 2087 existing tests pass
- [ ] On staging: load admin settings page, click Save without changing anything — should succeed
- [ ] Clear primary/accent color fields, save — should store null without error
- [ ] Set primary color to a valid hex, save — should persist correctly