### PR TITLE
ci: make lockfile sync non-blocking

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,6 +26,7 @@ jobs:
             }
 
       - name: Sync workspace lockfile
+        continue-on-error: true
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.DEPLOY_PAT }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the "Sync workspace lockfile" step in `deploy-staging.yml`
- The `DEPLOY_PAT` token does not have permission for `barazo-forum/barazo-workspace`, causing this step to fail with `Resource not accessible by personal access token`
- The failure was blocking the entire deploy workflow, even though the actual deploy dispatch to `barazo-deploy` succeeds

## Test plan
- [ ] Merge and verify the deploy workflow completes successfully on next push to main
- [ ] Confirm the lockfile sync step shows as a non-fatal warning rather than a failure

Fixes barazo-forum/barazo-workspace#146