### PR TITLE
ci(api): composite setup action + lexicons cache + dependency graph

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,30 @@
+name: Setup Barazo API
+description: Install pnpm/Node.js, cache and build lexicons, install dependencies
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version: 24
+        cache: 'pnpm'
+
+    - name: Cache lexicons build
+      id: lexicons-cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ../barazo-lexicons
+        key: lexicons-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Clone and build barazo-lexicons
+      if: steps.lexicons-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
+        cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm lint
 
   typecheck:
@@ -38,40 +29,24 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm typecheck
 
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [lint, typecheck]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm test
 
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [test]
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -97,16 +72,7 @@ jobs:
           --health-retries 3
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm db:migrate
         env:
           DATABASE_URL: postgresql://barazo:barazo_dev@localhost:5432/barazo
@@ -123,34 +89,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm build
 
   schema-check:
     name: Schema Drift Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [lint]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Check for uncommitted schema changes
         run: |
           pnpm db:generate --name=ci-check
@@ -168,16 +117,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 24
-          cache: 'pnpm'
-      - name: Clone and build barazo-lexicons
-        run: |
-          git clone --depth 1 https://github.com/barazo-forum/barazo-lexicons.git ../barazo-lexicons
-          cd ../barazo-lexicons && pnpm install --ignore-scripts && pnpm run build
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Security audit with retry
         run: |
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary
- Extract shared 5-step setup into `.github/actions/setup` composite action, reducing duplication across 7 jobs
- Cache lexicons build keyed on `pnpm-lock.yaml` hash -- eliminates redundant `git clone` + `pnpm install` + `pnpm build` on cache hits (~6 min saved across all jobs)
- Add job dependency graph: `lint` + `typecheck` gate `test`, `test` gates `test-integration`, `schema-check` needs `lint`. `build` and `security` run independently for fast signal.

Part of CI pipeline optimization (Phase 2). Depends on #127 (timeouts).

## Test plan
- [ ] CI passes on this PR (validates composite action works)
- [ ] Verify lexicons cache is populated on first run
- [ ] Verify dependency graph: if lint fails, test + test-integration + schema-check are skipped
- [ ] Verify build and security still run independently