### PR TITLE
fix(ci): route deploy through lockfile sync to prevent stale lockfile

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,23 +12,18 @@ jobs:
     name: Trigger Staging Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to barazo-deploy
+      # Sync the workspace lockfile first, then let it trigger the deploy.
+      # This avoids a race condition where the deploy starts with a stale
+      # lockfile before the sync has committed the updated one.
+      - name: Sync lockfile and deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.DEPLOY_PAT }}
-          repository: barazo-forum/barazo-deploy
-          event-type: deploy-staging
+          repository: barazo-forum/barazo-workspace
+          event-type: sync-lockfile
           client-payload: |
             {
               "trigger_repo": "barazo-api",
               "api_ref": "${{ github.sha }}",
               "web_ref": "main"
             }
-
-      - name: Sync workspace lockfile
-        continue-on-error: true
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.DEPLOY_PAT }}
-          repository: barazo-forum/barazo-workspace
-          event-type: sync-lockfile


### PR DESCRIPTION
## Summary

- Replaces the two-step dispatch (deploy + sync in parallel) with a single dispatch to `barazo-workspace`'s sync-lockfile workflow
- The sync workflow regenerates the lockfile if needed, then triggers the deploy with the correct refs
- Removes `continue-on-error: true` that was silently swallowing dispatch failures

Depends on barazo-forum/barazo-workspace#72.

## Context

When a PR added new dependencies, both dispatch steps fired simultaneously:
1. Deploy started immediately with the stale workspace lockfile -> `ERR_PNPM_OUTDATED_LOCKFILE`
2. Lockfile sync was supposed to update it and re-deploy, but the dispatch was failing silently

New flow: **PR merge -> sync lockfile -> deploy**. Serial, no race.

## Test plan

- [ ] Merge barazo-workspace#72 first
- [ ] Merge this PR, verify lockfile sync fires and deploy succeeds