### PR TITLE
fix(ci): use DEPLOY_PAT in fix-lockfile workflow

### DIFF
--- a/.github/workflows/fix-lockfile.yml
+++ b/.github/workflows/fix-lockfile.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOY_PAT }}
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 


### PR DESCRIPTION
## Summary
- Switches the fix-lockfile workflow from `GITHUB_TOKEN` to `DEPLOY_PAT`
- Commits pushed with `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-recursion guard), so CI never ran against the fixed lockfile

## Context
The fix-lockfile workflow (merged earlier today) correctly regenerates `pnpm-lock.yaml` on Dependabot PRs, but CI didn't re-run because the commit was pushed with the default token. See barazo-lexicons#48 where the lockfile fix landed but CI still shows as failed.

## Test plan
- [ ] After merge, comment `@dependabot recreate` on lexicons#48 and verify CI runs against the fixed lockfile commit