### PR TITLE
fix(topics): enrich author profile in single-topic detail endpoints

### DIFF
--- a/src/routes/topics.ts
+++ b/src/routes/topics.ts
@@ -831,7 +831,18 @@ export function topicRoutes(): FastifyPluginCallback {
           throw forbidden('Content restricted by maturity settings')
         }
 
-        return reply.status(200).send(serializeTopic(row, categoryRating))
+        const serialized = serializeTopic(row, categoryRating)
+        const authorMap = await resolveAuthors([row.authorDid], communityDid, db)
+
+        return reply.status(200).send({
+          ...serialized,
+          author: authorMap.get(row.authorDid) ?? {
+            did: row.authorDid,
+            handle: row.authorDid,
+            displayName: null,
+            avatarUrl: null,
+          },
+        })
       }
     )
 
@@ -907,7 +918,18 @@ export function topicRoutes(): FastifyPluginCallback {
           throw forbidden('Content restricted by maturity settings')
         }
 
-        return reply.status(200).send(serializeTopic(row, categoryRating))
+        const serialized = serializeTopic(row, categoryRating)
+        const authorMap = await resolveAuthors([row.authorDid], communityDid, db)
+
+        return reply.status(200).send({
+          ...serialized,
+          author: authorMap.get(row.authorDid) ?? {
+            did: row.authorDid,
+            handle: row.authorDid,
+            displayName: null,
+            avatarUrl: null,
+          },
+        })
       }
     )
 

--- a/tests/unit/routes/topics.test.ts
+++ b/tests/unit/routes/topics.test.ts
@@ -949,6 +949,48 @@ describe('topic routes', () => {
       expect(body.title).toBe('Test Topic Title')
     })
 
+    it('enriches author profile in single topic response', async () => {
+      const row = sampleTopicRow()
+      // 1. find topic
+      selectChain.where.mockResolvedValueOnce([row])
+      // 2. category maturity rating
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // 3. user profile (maturity)
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: null, maturityPref: 'safe' }])
+      // 4. age threshold
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // 5. resolveAuthors: users table
+      selectChain.where.mockResolvedValueOnce([
+        {
+          did: TEST_DID,
+          handle: TEST_HANDLE,
+          displayName: 'Jay',
+          avatarUrl: 'https://cdn.example.com/jay.jpg',
+          bannerUrl: null,
+          bio: null,
+        },
+      ])
+      // 6. resolveAuthors: community profiles
+      selectChain.where.mockResolvedValueOnce([])
+
+      const encodedUri = encodeURIComponent(TEST_URI)
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/${encodedUri}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        author: { did: string; handle: string; displayName: string; avatarUrl: string }
+      }>()
+      expect(body.author).toEqual({
+        did: TEST_DID,
+        handle: TEST_HANDLE,
+        displayName: 'Jay',
+        avatarUrl: 'https://cdn.example.com/jay.jpg',
+      })
+    })
+
     it('returns 404 for non-existent topic', async () => {
       selectChain.where.mockResolvedValueOnce([])
 
@@ -1047,6 +1089,47 @@ describe('topic routes', () => {
       const body = response.json<{ uri: string; title: string; rkey: string }>()
       expect(body.uri).toBe(TEST_URI)
       expect(body.title).toBe('Test Topic Title')
+    })
+
+    it('enriches author profile in by-rkey response', async () => {
+      const row = sampleTopicRow()
+      // 1. find topic
+      selectChain.where.mockResolvedValueOnce([row])
+      // 2. category maturity rating
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // 3. user profile (maturity)
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: null, maturityPref: 'safe' }])
+      // 4. age threshold
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // 5. resolveAuthors: users table
+      selectChain.where.mockResolvedValueOnce([
+        {
+          did: TEST_DID,
+          handle: TEST_HANDLE,
+          displayName: 'Jay',
+          avatarUrl: 'https://cdn.example.com/jay.jpg',
+          bannerUrl: null,
+          bio: null,
+        },
+      ])
+      // 6. resolveAuthors: community profiles
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/topics/by-rkey/abc123',
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        author: { did: string; handle: string; displayName: string; avatarUrl: string }
+      }>()
+      expect(body.author).toEqual({
+        did: TEST_DID,
+        handle: TEST_HANDLE,
+        displayName: 'Jay',
+        avatarUrl: 'https://cdn.example.com/jay.jpg',
+      })
     })
 
     it('returns 404 for non-existent rkey', async () => {


### PR DESCRIPTION
## Summary
- The `GET /api/topics/by-rkey/:rkey` and `GET /api/topics/:uri` endpoints returned raw `authorDid` without calling `resolveAuthors()`, while the list endpoint (`GET /api/topics`) already enriched the author profile
- This caused the frontend to display `did:plc:...` instead of display name + avatar on the topic detail page (opening post)
- Both single-topic endpoints now call `resolveAuthors()` before returning, matching the list endpoint pattern

Fixes barazo-forum/barazo-workspace#188

## Test plan
- [x] 2 new tests: verify author enrichment for both by-rkey and by-URI endpoints
- [x] All 2228 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] CI passes