### PR TITLE
fix(topics): enrich author profile in by-author-rkey endpoints

### DIFF
--- a/src/routes/replies.ts
+++ b/src/routes/replies.ts
@@ -741,7 +741,19 @@ export function replyRoutes(): FastifyPluginCallback {
           throw notFound('Reply not found')
         }
 
-        return reply.status(200).send(serializeReply(row))
+        const serialized = serializeReply(row)
+        const communityDid = requireCommunityDid(request)
+        const authorMap = await resolveAuthors([row.authorDid], communityDid, db)
+
+        return reply.status(200).send({
+          ...serialized,
+          author: authorMap.get(row.authorDid) ?? {
+            did: row.authorDid,
+            handle: row.authorDid,
+            displayName: null,
+            avatarUrl: null,
+          },
+        })
       }
     )
 

--- a/src/routes/topics.ts
+++ b/src/routes/topics.ts
@@ -921,7 +921,18 @@ export function topicRoutes(): FastifyPluginCallback {
           throw forbidden('Content restricted by maturity settings')
         }
 
-        return reply.status(200).send(serializeTopic(row, categoryRating))
+        const serialized = serializeTopic(row, categoryRating)
+        const authorMap = await resolveAuthors([row.authorDid], communityDid, db)
+
+        return reply.status(200).send({
+          ...serialized,
+          author: authorMap.get(row.authorDid) ?? {
+            did: row.authorDid,
+            handle: row.authorDid,
+            displayName: null,
+            avatarUrl: null,
+          },
+        })
       }
     )
 

--- a/tests/unit/routes/replies.test.ts
+++ b/tests/unit/routes/replies.test.ts
@@ -2617,6 +2617,42 @@ describe('reply routes', () => {
       expect(response.statusCode).toBe(404)
     })
 
+    it('enriches author profile in by-author-rkey response', async () => {
+      resolveHandleToDidFn.mockResolvedValueOnce(TEST_DID)
+      const row = sampleReplyRow()
+      // 1. find reply by authorDid + rkey
+      selectChain.where.mockResolvedValueOnce([row])
+      // 2. resolveAuthors: users table
+      selectChain.where.mockResolvedValueOnce([
+        {
+          did: TEST_DID,
+          handle: TEST_HANDLE,
+          displayName: 'Jay',
+          avatarUrl: 'https://cdn.example.com/jay.jpg',
+          bannerUrl: null,
+          bio: null,
+        },
+      ])
+      // 3. resolveAuthors: community profiles
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/replies/by-author-rkey/${TEST_HANDLE}/${TEST_REPLY_RKEY}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        author: { did: string; handle: string; displayName: string; avatarUrl: string }
+      }>()
+      expect(body.author).toEqual({
+        did: TEST_DID,
+        handle: TEST_HANDLE,
+        displayName: 'Jay',
+        avatarUrl: 'https://cdn.example.com/jay.jpg',
+      })
+    })
+
     it('returns 404 when reply not found for author', async () => {
       resolveHandleToDidFn.mockResolvedValueOnce(TEST_DID)
       selectChain.where.mockResolvedValueOnce([])

--- a/tests/unit/routes/topics.test.ts
+++ b/tests/unit/routes/topics.test.ts
@@ -1280,6 +1280,48 @@ describe('topic routes', () => {
       expect(response.statusCode).toBe(404)
     })
 
+    it('enriches author profile in by-author-rkey response', async () => {
+      resolveHandleToDidFn.mockResolvedValueOnce(TEST_DID)
+      const row = sampleTopicRow()
+      // 1. find topic by authorDid + rkey
+      selectChain.where.mockResolvedValueOnce([row])
+      // 2. category maturity rating
+      selectChain.where.mockResolvedValueOnce([{ maturityRating: 'safe' }])
+      // 3. user profile (maturity)
+      selectChain.where.mockResolvedValueOnce([{ declaredAge: null, maturityPref: 'safe' }])
+      // 4. age threshold
+      selectChain.where.mockResolvedValueOnce([{ ageThreshold: 16 }])
+      // 5. resolveAuthors: users table
+      selectChain.where.mockResolvedValueOnce([
+        {
+          did: TEST_DID,
+          handle: TEST_HANDLE,
+          displayName: 'Jay',
+          avatarUrl: 'https://cdn.example.com/jay.jpg',
+          bannerUrl: null,
+          bio: null,
+        },
+      ])
+      // 6. resolveAuthors: community profiles
+      selectChain.where.mockResolvedValueOnce([])
+
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/topics/by-author-rkey/${TEST_HANDLE}/${TEST_RKEY}`,
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{
+        author: { did: string; handle: string; displayName: string; avatarUrl: string }
+      }>()
+      expect(body.author).toEqual({
+        did: TEST_DID,
+        handle: TEST_HANDLE,
+        displayName: 'Jay',
+        avatarUrl: 'https://cdn.example.com/jay.jpg',
+      })
+    })
+
     it('returns 403 when maturity blocks access', async () => {
       const noAuthApp = await buildTestApp(undefined)
 


### PR DESCRIPTION
## Summary

- The `GET /api/topics/by-author-rkey/:handle/:rkey` and `GET /api/replies/by-author-rkey/:handle/:rkey` endpoints returned raw `authorDid` without resolving the author profile
- This regressed the fix from #138 (which covered `by-rkey` and `by-uri` but not the new `by-author-rkey` endpoints added in #139)
- The frontend switched to `by-author-rkey` in barazo-forum/barazo-web#177, causing DIDs to display instead of profile name/avatar in the OP

Fixes barazo-forum/barazo-workspace#171

## Changes

- Add `resolveAuthors()` enrichment to topic `by-author-rkey` handler (matching pattern from `by-rkey` and `by-uri`)
- Add `resolveAuthors()` enrichment to reply `by-author-rkey` handler
- Add test coverage for author enrichment in both endpoints

## Test plan

- [x] `npx vitest run tests/unit/routes/topics.test.ts` — 124 tests pass
- [x] `npx vitest run tests/unit/routes/replies.test.ts` — 89 tests pass
- [x] TypeScript typecheck clean
- [ ] CI passes
- [ ] After deploy: verify topic detail page shows profile name and avatar instead of DID