### PR TITLE
feat(reactions): prevent users from reacting to their own content

### DIFF
--- a/src/firehose/indexers/reaction.ts
+++ b/src/firehose/indexers/reaction.ts
@@ -39,6 +39,14 @@ export class ReactionIndexer {
   async handleCreate(params: CreateParams): Promise<void> {
     const { uri, rkey, did, cid, record, live } = params
     const { subject } = record
+
+    // Skip self-reactions: extract the subject author DID from the AT URI
+    const subjectAuthorDid = subject.uri.split('/')[2]
+    if (subjectAuthorDid === did) {
+      this.logger.debug({ uri, did }, 'Skipping self-reaction')
+      return
+    }
+
     const clientCreatedAt = new Date(record.createdAt)
     const createdAt = live ? clampCreatedAt(clientCreatedAt) : clientCreatedAt
 

--- a/src/routes/reactions.ts
+++ b/src/routes/reactions.ts
@@ -213,6 +213,10 @@ export function reactionRoutes(): FastifyPluginCallback {
           throw notFound('Subject not found')
         }
 
+        if (subjectAuthorDid === user.did) {
+          throw forbidden('Cannot react to your own content')
+        }
+
         const now = new Date().toISOString()
 
         // Build AT Protocol record

--- a/tests/unit/firehose/indexers/reaction.test.ts
+++ b/tests/unit/firehose/indexers/reaction.test.ts
@@ -67,7 +67,7 @@ describe('ReactionIndexer', () => {
         ...baseParams,
         record: {
           subject: {
-            uri: 'at://did:plc:test/forum.barazo.topic.post/topic1',
+            uri: 'at://did:plc:other/forum.barazo.topic.post/topic1',
             cid: 'bafytopic',
           },
           type: 'like',
@@ -77,6 +77,31 @@ describe('ReactionIndexer', () => {
       })
 
       expect(db.transaction).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips self-reactions without indexing', async () => {
+      const db = createMockDb()
+      const logger = createMockLogger()
+      const indexer = new ReactionIndexer(db as never, logger as never)
+
+      await indexer.handleCreate({
+        ...baseParams,
+        record: {
+          subject: {
+            uri: 'at://did:plc:test/forum.barazo.topic.post/topic1',
+            cid: 'bafytopic',
+          },
+          type: 'like',
+          community: 'did:plc:community',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      })
+
+      expect(db.transaction).not.toHaveBeenCalled()
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ did: 'did:plc:test' }),
+        'Skipping self-reaction'
+      )
     })
   })
 

--- a/tests/unit/routes/reactions.test.ts
+++ b/tests/unit/routes/reactions.test.ts
@@ -235,8 +235,8 @@ describe('reaction routes', () => {
     it('creates a reaction on a topic and returns 201', async () => {
       // 1. Community settings query -> reactionSet includes "like"
       selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like', 'heart'] }])
-      // 2. Subject existence check -> topic found
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI }])
+      // 2. Subject existence check -> topic found (authored by OTHER_DID)
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI, authorDid: OTHER_DID }])
       // 3. Insert returning
       insertChain.returning.mockResolvedValueOnce([sampleReactionRow()])
 
@@ -278,8 +278,8 @@ describe('reaction routes', () => {
     it('creates a reaction on a reply and returns 201', async () => {
       // 1. Community settings
       selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
-      // 2. Subject existence check -> reply found
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_REPLY_URI }])
+      // 2. Subject existence check -> reply found (authored by OTHER_DID)
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_REPLY_URI, authorDid: OTHER_DID }])
       // 3. Insert returning
       const replyReaction = sampleReactionRow({
         subjectUri: TEST_REPLY_URI,
@@ -308,7 +308,7 @@ describe('reaction routes', () => {
       trackRepoFn.mockResolvedValue(undefined)
 
       selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI }])
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI, authorDid: OTHER_DID }])
       insertChain.returning.mockResolvedValueOnce([sampleReactionRow()])
 
       const response = await app.inject({
@@ -416,8 +416,8 @@ describe('reaction routes', () => {
     it("uses default reaction set ['like'] when no settings exist", async () => {
       // No settings row found
       selectChain.where.mockResolvedValueOnce([])
-      // Subject exists
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI }])
+      // Subject exists (authored by OTHER_DID)
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI, authorDid: OTHER_DID }])
       insertChain.returning.mockResolvedValueOnce([sampleReactionRow()])
 
       const response = await app.inject({
@@ -432,6 +432,51 @@ describe('reaction routes', () => {
       })
 
       expect(response.statusCode).toBe(201)
+    })
+
+    it('returns 403 when reacting to own content (topic)', async () => {
+      // User's own topic URI uses TEST_DID as the author
+      const ownTopicUri = `at://${TEST_DID}/forum.barazo.topic.post/mytopic1`
+
+      selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
+      selectChain.where.mockResolvedValueOnce([{ uri: ownTopicUri, authorDid: TEST_DID }])
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reactions',
+        headers: { authorization: 'Bearer test-token' },
+        payload: {
+          subjectUri: ownTopicUri,
+          subjectCid: TEST_TOPIC_CID,
+          type: 'like',
+        },
+      })
+
+      expect(response.statusCode).toBe(403)
+      const body = response.json<{ message: string }>()
+      expect(body.message).toMatch(/own/i)
+      expect(createRecordFn).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when reacting to own content (reply)', async () => {
+      const ownReplyUri = `at://${TEST_DID}/forum.barazo.topic.reply/myreply1`
+
+      selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
+      selectChain.where.mockResolvedValueOnce([{ uri: ownReplyUri, authorDid: TEST_DID }])
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/reactions',
+        headers: { authorization: 'Bearer test-token' },
+        payload: {
+          subjectUri: ownReplyUri,
+          subjectCid: TEST_REPLY_CID,
+          type: 'like',
+        },
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(createRecordFn).not.toHaveBeenCalled()
     })
 
     it('returns 404 when subject does not exist', async () => {
@@ -473,7 +518,7 @@ describe('reaction routes', () => {
 
     it('returns 409 when duplicate reaction (unique constraint)', async () => {
       selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI }])
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI, authorDid: OTHER_DID }])
       // onConflictDoNothing -> returning() returns empty array
       insertChain.returning.mockResolvedValueOnce([])
 
@@ -493,7 +538,7 @@ describe('reaction routes', () => {
 
     it('returns 502 when PDS write fails', async () => {
       selectChain.where.mockResolvedValueOnce([{ reactionSet: ['like'] }])
-      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI }])
+      selectChain.where.mockResolvedValueOnce([{ uri: TEST_TOPIC_URI, authorDid: OTHER_DID }])
       createRecordFn.mockRejectedValueOnce(new Error('PDS unreachable'))
 
       const response = await app.inject({


### PR DESCRIPTION
## Summary
- Add self-reaction guard in POST `/api/reactions` returning 403 before PDS write
- Add secondary defense in firehose indexer to skip indexing self-reactions
- Add tests for both enforcement points

## Changes
- `src/routes/reactions.ts` — check `subjectAuthorDid === user.did` after subject lookup, before PDS write
- `src/firehose/indexers/reaction.ts` — extract subject author DID from AT URI, skip if same as reactor
- `tests/unit/routes/reactions.test.ts` — 2 new tests (topic + reply self-reaction), updated mocks to include `authorDid`
- `tests/unit/firehose/indexers/reaction.test.ts` — new self-reaction skip test, fixed existing test

## Test plan
- [x] 39 unit tests pass (reactions route + firehose indexer)
- [ ] CI passes (lint, typecheck, build, tests)

Companion PR: singi-labs/barazo-web (frontend disable)