### PR TITLE
feat(plugins): link signatures plugin for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@atproto/api": "0.19.0",
     "@atproto/oauth-client-node": "0.3.17",
     "@atproto/tap": "0.2.7",
+    "@barazo/plugin-signatures": "link:../barazo-plugins/packages/plugin-signatures",
     "@singi-labs/lexicons": "link:../barazo-lexicons",
     "@fastify/cookie": "11.0.2",
     "@fastify/cors": "11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@atproto/tap':
         specifier: 0.2.7
         version: 0.2.7
+      '@barazo/plugin-signatures':
+        specifier: link:../barazo-plugins/packages/plugin-signatures
+        version: link:../barazo-plugins/packages/plugin-signatures
       '@fastify/cookie':
         specifier: 11.0.2
         version: 11.0.2


### PR DESCRIPTION
## Summary

- Adds `@barazo/plugin-signatures` as a `link:` dependency pointing to the sibling `barazo-plugins` monorepo
- Plugin loader (`src/lib/plugins/loader.ts`) can now discover the signatures plugin manifest from `node_modules/@barazo/plugin-signatures/plugin.json`
- No runtime changes — the infrastructure wiring gaps (lifecycle hooks, route mounting, PluginContext construction) are tracked in `specs/plugin-system-implementation.md` and will be addressed separately

## Test plan

- [x] `pnpm install` resolves the link
- [x] `plugin.json` accessible at `node_modules/@barazo/plugin-signatures/plugin.json`
- [x] All 2327 existing tests pass
- [x] Lint, typecheck, build all clean