### PR TITLE
feat(plugins): wire plugin runtime infrastructure

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import Fastify from 'fastify'
 import helmet from '@fastify/helmet'
 import cors from '@fastify/cors'
@@ -7,7 +8,7 @@ import rateLimit from '@fastify/rate-limit'
 import swagger from '@fastify/swagger'
 import scalarApiReference from '@scalar/fastify-api-reference'
 import * as Sentry from '@sentry/node'
-import type { FastifyError } from 'fastify'
+import type { FastifyError, FastifyPluginCallback } from 'fastify'
 import type { NodeOAuthClient } from '@atproto/oauth-client-node'
 import { sql } from 'drizzle-orm'
 import type { Env } from './config/env.js'
@@ -47,6 +48,10 @@ import { adminSybilRoutes } from './routes/admin-sybil.js'
 import { adminDesignRoutes } from './routes/admin-design.js'
 import { adminPluginRoutes } from './routes/admin-plugins.js'
 import { discoverPlugins, syncPluginsToDb, validateAndFilterPlugins } from './lib/plugins/loader.js'
+import { buildLoadedPlugin, executeHook, getPluginShortName } from './lib/plugins/runtime.js'
+import { createPluginContext, type CacheAdapter } from './lib/plugins/context.js'
+import type { PluginContext } from './lib/plugins/types.js'
+import type { LoadedPlugin } from './lib/plugins/types.js'
 import { createRequireAdmin } from './auth/require-admin.js'
 import { createRequireOperator } from './auth/require-operator.js'
 import { OzoneService } from './services/ozone.js'
@@ -86,6 +91,8 @@ declare module 'fastify' {
     storage: StorageService
     interactionGraphService: InteractionGraphService
     trustGraphService: TrustGraphService
+    loadedPlugins: Map<string, LoadedPlugin>
+    enabledPlugins: Set<string>
   }
 }
 
@@ -122,6 +129,9 @@ export async function buildApp(env: Env) {
   // Plugin discovery and DB sync
   const nodeModulesPath = new URL('../node_modules', import.meta.url).pathname
   const discovered = await discoverPlugins(nodeModulesPath, app.log)
+  const loadedPlugins = new Map<string, LoadedPlugin>()
+  const enabledPlugins = new Set<string>()
+
   if (discovered.length > 0) {
     const validManifests = validateAndFilterPlugins(
       discovered.map((d) => d.manifest),
@@ -129,10 +139,49 @@ export async function buildApp(env: Env) {
       app.log
     )
     app.log.info({ count: validManifests.length }, 'Plugins discovered')
-    await syncPluginsToDb(discovered, db, app.log)
+
+    const syncResult = await syncPluginsToDb(discovered, db, app.log)
+
+    // Build LoadedPlugin objects (resolve hooks, route paths)
+    for (const { manifest, packagePath } of discovered) {
+      const loaded = await buildLoadedPlugin(manifest, packagePath, app.log)
+      loadedPlugins.set(manifest.name, loaded)
+    }
+
+    // Run onInstall for newly discovered plugins
+    for (const newName of syncResult.newPlugins) {
+      const loaded = loadedPlugins.get(newName)
+      if (loaded?.hooks?.onInstall) {
+        const ctx = createPluginContext({
+          pluginName: loaded.name,
+          pluginVersion: loaded.version,
+          permissions: [],
+          settings: {},
+          db,
+          cache: null,
+          oauthClient: null,
+          logger: app.log,
+          communityDid: getCommunityDid(env),
+        })
+        // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+        const hookFn = loaded.hooks.onInstall as (...args: unknown[]) => Promise<void>
+        await executeHook('onInstall', hookFn, ctx, app.log, loaded.name)
+      }
+    }
+
+    // Track enabled plugins
+    const enabledRows = (await db.execute(
+      sql`SELECT name FROM plugins WHERE enabled = true`
+    )) as unknown as Array<{ name: string }>
+    for (const row of enabledRows) {
+      enabledPlugins.add(row.name)
+    }
   } else {
     app.log.info('No plugins discovered')
   }
+
+  app.decorate('loadedPlugins', loadedPlugins)
+  app.decorate('enabledPlugins', enabledPlugins)
 
   // Cache
   const cache = createCache(env.VALKEY_URL, app.log)
@@ -239,8 +288,31 @@ export async function buildApp(env: Env) {
   const handleResolver = createHandleResolver(cache, db, app.log)
   app.decorate('handleResolver', handleResolver)
 
+  // Wrap Valkey/ioredis client as CacheAdapter for plugin contexts
+  const pluginCacheAdapter: CacheAdapter = {
+    async get(key: string): Promise<string | null> {
+      return cache.get(key)
+    },
+    async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+      if (ttlSeconds !== undefined) {
+        await cache.set(key, value, 'EX', ttlSeconds)
+      } else {
+        await cache.set(key, value)
+      }
+    },
+    async del(key: string): Promise<void> {
+      await cache.del(key)
+    },
+  }
+
   // Profile sync (fetches AT Protocol profile from Bluesky public API at login)
-  const profileSync = createProfileSyncService(db, app.log)
+  const profileSync = createProfileSyncService(db, app.log, {
+    loadedPlugins,
+    enabledPlugins,
+    oauthClient,
+    cache: pluginCacheAdapter,
+    communityDid: getCommunityDid(env),
+  })
   app.decorate('profileSync', profileSync)
 
   // PLC DID service + Setup service
@@ -276,6 +348,80 @@ export async function buildApp(env: Env) {
     ozoneService = new OzoneService(db, cache, app.log, env.OZONE_LABELER_URL)
   }
   app.decorate('ozoneService', ozoneService)
+
+  // Register plugin routes under /api/ext/<short-name>/
+  for (const [, loaded] of loadedPlugins) {
+    if (!loaded.routesPath) continue
+
+    const shortName = getPluginShortName(loaded.name)
+    const routesFullPath = join(loaded.packagePath, loaded.routesPath)
+
+    try {
+      const routeModule = (await import(routesFullPath)) as Record<string, unknown>
+
+      // Find the exported Fastify plugin function (convention: first function export)
+      const routeFn = Object.values(routeModule).find((v) => typeof v === 'function') as
+        | FastifyPluginCallback<{ ctx: PluginContext }>
+        | undefined
+
+      if (!routeFn) {
+        app.log.warn({ plugin: loaded.name }, 'No route function export found')
+        continue
+      }
+
+      // Query settings for this plugin from DB
+      const pluginRows = (await db.execute(
+        sql`SELECT id FROM plugins WHERE name = ${loaded.name}`
+      )) as unknown as Array<{ id: string }>
+      const pluginId = pluginRows[0]?.id
+
+      const settingsObj: Record<string, unknown> = {}
+      if (pluginId) {
+        const settingsRows = (await db.execute(
+          sql`SELECT key, value FROM plugin_settings WHERE plugin_id = ${pluginId}`
+        )) as unknown as Array<{ key: string; value: unknown }>
+        for (const s of settingsRows) {
+          settingsObj[s.key] = s.value
+        }
+      }
+
+      // Get permissions from manifest
+      const manifestData = loaded.manifest as { permissions?: { backend?: string[] } }
+      const permissions = manifestData.permissions?.backend ?? []
+
+      const ctx = createPluginContext({
+        pluginName: loaded.name,
+        pluginVersion: loaded.version,
+        permissions,
+        settings: settingsObj,
+        db,
+        cache: pluginCacheAdapter,
+        oauthClient,
+        logger: app.log,
+        communityDid: getCommunityDid(env),
+      })
+
+      // Register in a scoped plugin with enabled-check preHandler
+      await app.register(
+        async function pluginRouteScope(scope) {
+          scope.addHook('preHandler', async (_request, reply) => {
+            if (!app.enabledPlugins.has(loaded.name)) {
+              return reply.status(404).send({ error: 'Plugin not available' })
+            }
+          })
+          await scope.register(routeFn, { ctx })
+        },
+        { prefix: `/api/ext/${shortName}` }
+      )
+
+      app.log.info(
+        { plugin: loaded.name, prefix: `/api/ext/${shortName}` },
+        'Plugin routes registered'
+      )
+    } catch (err: unknown) {
+      app.log.error({ err, plugin: loaded.name }, 'Failed to register plugin routes')
+    }
+  }
 
   // OpenAPI documentation (register before routes so schemas are collected)
   await app.register(swagger, {

--- a/src/lib/plugins/context.ts
+++ b/src/lib/plugins/context.ts
@@ -1,6 +1,14 @@
+import { Agent } from '@atproto/api'
+
 import type { Logger } from '../logger.js'
 
-import type { PluginContext, PluginSettings, ScopedCache, ScopedDatabase } from './types.js'
+import type {
+  PluginContext,
+  PluginSettings,
+  ScopedAtProto,
+  ScopedCache,
+  ScopedDatabase,
+} from './types.js'
 
 /** Adapter interface for the underlying cache (e.g. Valkey/ioredis). */
 export interface CacheAdapter {
@@ -16,6 +24,7 @@ export interface PluginContextOptions {
   settings: Record<string, unknown>
   db: unknown
   cache: CacheAdapter | null
+  oauthClient: unknown // NodeOAuthClient | null — typed as unknown to avoid coupling
   logger: Logger
   communityDid: string
 }
@@ -59,14 +68,82 @@ function createScopedDatabase(db: unknown, _permissions: string[]): ScopedDataba
   }
 }
 
+const BSKY_PUBLIC_API = 'https://public.api.bsky.app'
+
+interface OAuthClientLike {
+  restore(did: string): Promise<unknown>
+}
+
+function createScopedAtProto(
+  oauthClient: OAuthClientLike,
+  logger: Logger,
+  pluginName: string
+): ScopedAtProto {
+  return {
+    async getRecord(did: string, collection: string, rkey: string): Promise<unknown> {
+      try {
+        const agent = new Agent(new URL(BSKY_PUBLIC_API))
+        const response = await agent.com.atproto.repo.getRecord({
+          repo: did,
+          collection,
+          rkey,
+        })
+        return response.data.value
+      } catch (err: unknown) {
+        logger.debug(
+          { err, plugin: pluginName, did, collection, rkey },
+          'ScopedAtProto getRecord failed'
+        )
+        return null
+      }
+    },
+
+    async putRecord(did: string, collection: string, rkey: string, record: unknown): Promise<void> {
+      const session = await oauthClient.restore(did)
+      const agent = new Agent(session as ConstructorParameters<typeof Agent>[0])
+      await agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection,
+        rkey,
+        record: { $type: collection, ...(record as Record<string, unknown>) },
+      })
+    },
+
+    async deleteRecord(did: string, collection: string, rkey: string): Promise<void> {
+      const session = await oauthClient.restore(did)
+      const agent = new Agent(session as ConstructorParameters<typeof Agent>[0])
+      await agent.com.atproto.repo.deleteRecord({
+        repo: did,
+        collection,
+        rkey,
+      })
+    },
+  }
+}
+
 export function createPluginContext(options: PluginContextOptions): PluginContext {
-  const { pluginName, pluginVersion, permissions, settings, db, cache, logger, communityDid } =
-    options
+  const {
+    pluginName,
+    pluginVersion,
+    permissions,
+    settings,
+    db,
+    cache,
+    oauthClient,
+    logger,
+    communityDid,
+  } = options
 
   const hasCachePermission =
     permissions.includes('cache:read') || permissions.includes('cache:write')
 
   const scopedCache = hasCachePermission && cache ? createScopedCache(cache, pluginName) : undefined
+
+  const hasPdsPermission = permissions.includes('pds:read') || permissions.includes('pds:write')
+  const scopedAtProto =
+    hasPdsPermission && oauthClient
+      ? createScopedAtProto(oauthClient as OAuthClientLike, logger, pluginName)
+      : undefined
 
   return {
     pluginName,
@@ -76,5 +153,6 @@ export function createPluginContext(options: PluginContextOptions): PluginContex
     settings: createPluginSettings(settings),
     logger: logger.child({ plugin: pluginName }),
     ...(scopedCache ? { cache: scopedCache } : {}),
+    ...(scopedAtProto ? { atproto: scopedAtProto } : {}),
   } satisfies PluginContext
 }

--- a/src/lib/plugins/loader.ts
+++ b/src/lib/plugins/loader.ts
@@ -166,8 +166,17 @@ export async function syncPluginsToDb(
   discovered: { manifest: PluginManifest; packagePath: string }[],
   db: DbExecutor,
   logger: Logger
-): Promise<void> {
+): Promise<{ newPlugins: string[] }> {
+  const existingRows = (await db.execute(sql`SELECT name FROM plugins`)) as Array<{
+    name: string
+  }>
+  const existingNames = new Set(existingRows.map((r) => r.name))
+  const newPlugins: string[] = []
+
   for (const { manifest } of discovered) {
+    if (!existingNames.has(manifest.name)) {
+      newPlugins.push(manifest.name)
+    }
     const manifestJson = JSON.stringify(manifest)
 
     // Upsert plugin -- new plugins are inserted as disabled
@@ -206,4 +215,6 @@ export async function syncPluginsToDb(
 
     logger.info({ plugin: manifest.name, version: manifest.version }, 'Synced plugin to database')
   }
+
+  return { newPlugins }
 }

--- a/src/lib/plugins/runtime.ts
+++ b/src/lib/plugins/runtime.ts
@@ -1,0 +1,125 @@
+import { join } from 'node:path'
+
+import type { Logger } from '../logger.js'
+
+import type { PluginContext, PluginHooks, LoadedPlugin } from './types.js'
+import type { PluginManifest } from '../../validation/plugin-manifest.js'
+
+// ---------------------------------------------------------------------------
+// Hook reference parsing
+// ---------------------------------------------------------------------------
+
+export function resolveHookRef(ref: string): { modulePath: string; exportName: string } | null {
+  const hashIndex = ref.indexOf('#')
+  if (hashIndex <= 0) return null
+  return {
+    modulePath: ref.slice(0, hashIndex),
+    exportName: ref.slice(hashIndex + 1),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin short name
+// ---------------------------------------------------------------------------
+
+export function getPluginShortName(name: string): string {
+  if (name.startsWith('@barazo/plugin-')) return name.slice('@barazo/plugin-'.length)
+  if (name.startsWith('barazo-plugin-')) return name.slice('barazo-plugin-'.length)
+  return name
+}
+
+// ---------------------------------------------------------------------------
+// Hook execution
+// ---------------------------------------------------------------------------
+
+export async function executeHook(
+  hookName: string,
+  hookFn: (...args: unknown[]) => Promise<void> | void,
+  ctx: PluginContext,
+  logger: Logger,
+  pluginName: string,
+  ...extraArgs: unknown[]
+): Promise<boolean> {
+  try {
+    await hookFn(ctx, ...extraArgs)
+    logger.info({ plugin: pluginName, hook: hookName }, 'Plugin hook executed')
+    return true
+  } catch (err: unknown) {
+    logger.error({ err, plugin: pluginName, hook: hookName }, 'Plugin hook failed')
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load hooks from manifest
+// ---------------------------------------------------------------------------
+
+const HOOK_NAMES = ['onInstall', 'onUninstall', 'onEnable', 'onDisable', 'onProfileSync'] as const
+
+export async function loadPluginHooks(
+  packagePath: string,
+  manifest: PluginManifest,
+  logger: Logger
+): Promise<PluginHooks> {
+  const hooks: PluginHooks = {}
+  const hookEntries = manifest.hooks
+  if (!hookEntries) return hooks
+
+  for (const name of HOOK_NAMES) {
+    const ref = hookEntries[name]
+    if (!ref) continue
+
+    const parsed = resolveHookRef(ref)
+    if (!parsed) {
+      logger.warn({ plugin: manifest.name, hook: name, ref }, 'Invalid hook reference, skipping')
+      continue
+    }
+
+    try {
+      const fullPath = join(packagePath, parsed.modulePath)
+      const mod = (await import(fullPath)) as Record<string, unknown>
+      const fn = mod[parsed.exportName]
+      if (typeof fn === 'function') {
+        // Each hook is assigned individually after type-checking the export.
+        ;(hooks as Record<string, unknown>)[name] = fn
+      } else {
+        logger.warn(
+          { plugin: manifest.name, hook: name, export: parsed.exportName },
+          'Hook export is not a function'
+        )
+      }
+    } catch (err: unknown) {
+      logger.error({ err, plugin: manifest.name, hook: name }, 'Failed to load hook module')
+    }
+  }
+
+  return hooks
+}
+
+// ---------------------------------------------------------------------------
+// Build LoadedPlugin from discovery result
+// ---------------------------------------------------------------------------
+
+export async function buildLoadedPlugin(
+  manifest: PluginManifest,
+  packagePath: string,
+  logger: Logger
+): Promise<LoadedPlugin> {
+  const hooks = await loadPluginHooks(packagePath, manifest, logger)
+
+  return {
+    name: manifest.name,
+    displayName: manifest.displayName,
+    version: manifest.version,
+    description: manifest.description,
+    source: manifest.source,
+    category: manifest.category,
+    manifest: manifest as unknown as Record<string, unknown>,
+    packagePath,
+    hooks,
+    ...(manifest.backend?.routes !== undefined && { routesPath: manifest.backend.routes }),
+    ...(manifest.backend?.migrations !== undefined && {
+      migrationsPath: manifest.backend.migrations,
+    }),
+  }
+}

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -9,8 +9,8 @@ export interface ScopedDatabase {
 /** Scoped AT Protocol operations (only available if plugin has pds:read or pds:write permission). */
 export interface ScopedAtProto {
   getRecord(did: string, collection: string, rkey: string): Promise<unknown>
-  putRecord(collection: string, rkey: string, record: unknown): Promise<void>
-  deleteRecord(collection: string, rkey: string): Promise<void>
+  putRecord(did: string, collection: string, rkey: string, record: unknown): Promise<void>
+  deleteRecord(did: string, collection: string, rkey: string): Promise<void>
 }
 
 /** Scoped Valkey cache -- keys are auto-prefixed with plugin:<name>: */

--- a/src/routes/admin-plugins.ts
+++ b/src/routes/admin-plugins.ts
@@ -5,7 +5,13 @@ import { createRequire } from 'node:module'
 import { promisify } from 'node:util'
 import type { FastifyPluginCallback } from 'fastify'
 import { notFound, badRequest, conflict, errorResponseSchema } from '../lib/api-errors.js'
-import { getRegistryIndex, searchRegistryPlugins, getFeaturedPlugins } from '../lib/plugins/registry.js'
+import {
+  getRegistryIndex,
+  searchRegistryPlugins,
+  getFeaturedPlugins,
+} from '../lib/plugins/registry.js'
+import { executeHook, buildLoadedPlugin } from '../lib/plugins/runtime.js'
+import { createPluginContext } from '../lib/plugins/context.js'
 import { updatePluginSettingsSchema, installPluginSchema } from '../validation/admin-plugins.js'
 import { pluginManifestSchema } from '../validation/plugin-manifest.js'
 import { plugins, pluginSettings } from '../db/schema/plugins.js'
@@ -95,6 +101,21 @@ export function adminPluginRoutes(): FastifyPluginCallback {
   return (app, _opts, done) => {
     const { db } = app
     const requireAdmin = app.requireAdmin
+
+    function buildCtxForPlugin(pluginRow: typeof plugins.$inferSelect) {
+      const manifest = pluginRow.manifestJson as { permissions?: { backend?: string[] } }
+      return createPluginContext({
+        pluginName: pluginRow.name,
+        pluginVersion: pluginRow.version,
+        permissions: manifest.permissions?.backend ?? [],
+        settings: {},
+        db: app.db,
+        cache: null,
+        oauthClient: null,
+        logger: app.log,
+        communityDid: '',
+      })
+    }
 
     // -------------------------------------------------------------------
     // GET /api/plugins (admin only)
@@ -254,6 +275,16 @@ export function adminPluginRoutes(): FastifyPluginCallback {
           throw notFound('Plugin not found after update')
         }
 
+        // Execute onEnable hook
+        const loaded = app.loadedPlugins.get(plugin.name)
+        if (loaded?.hooks?.onEnable) {
+          const ctx = buildCtxForPlugin(updatedPlugin)
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+          const hookFn = loaded.hooks.onEnable as (...args: unknown[]) => Promise<void>
+          await executeHook('onEnable', hookFn, ctx, app.log, plugin.name)
+        }
+        app.enabledPlugins.add(plugin.name)
+
         app.log.info(
           {
             event: 'plugin_enabled',
@@ -336,6 +367,16 @@ export function adminPluginRoutes(): FastifyPluginCallback {
         if (!updatedPlugin) {
           throw notFound('Plugin not found after update')
         }
+
+        // Execute onDisable hook
+        const loaded = app.loadedPlugins.get(plugin.name)
+        if (loaded?.hooks?.onDisable) {
+          const ctx = buildCtxForPlugin(updatedPlugin)
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+          const hookFn = loaded.hooks.onDisable as (...args: unknown[]) => Promise<void>
+          await executeHook('onDisable', hookFn, ctx, app.log, plugin.name)
+        }
+        app.enabledPlugins.delete(plugin.name)
 
         app.log.info(
           {
@@ -491,7 +532,19 @@ export function adminPluginRoutes(): FastifyPluginCallback {
           )
         }
 
+        // Execute onUninstall hook before DB delete
+        const loaded = app.loadedPlugins.get(plugin.name)
+        if (loaded?.hooks?.onUninstall) {
+          const ctx = buildCtxForPlugin(plugin)
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+          const hookFn = loaded.hooks.onUninstall as (...args: unknown[]) => Promise<void>
+          await executeHook('onUninstall', hookFn, ctx, app.log, plugin.name)
+        }
+
         await db.delete(plugins).where(eq(plugins.id, id))
+
+        app.enabledPlugins.delete(plugin.name)
+        app.loadedPlugins.delete(plugin.name)
 
         app.log.info(
           {
@@ -592,6 +645,18 @@ export function adminPluginRoutes(): FastifyPluginCallback {
         const newPlugin = inserted[0]
         if (!newPlugin) {
           throw badRequest('Failed to insert plugin')
+        }
+
+        // Load hooks for newly installed plugin and run onInstall
+        const packageDirPath = packageDir.replace(/\/plugin\.json$/, '')
+        const loadedPlugin = await buildLoadedPlugin(manifest, packageDirPath, app.log)
+        app.loadedPlugins.set(manifest.name, loadedPlugin)
+
+        if (loadedPlugin.hooks?.onInstall) {
+          const ctx = buildCtxForPlugin(newPlugin)
+          // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+          const hookFn = loadedPlugin.hooks.onInstall as (...args: unknown[]) => Promise<void>
+          await executeHook('onInstall', hookFn, ctx, app.log, manifest.name)
         }
 
         app.log.info(

--- a/src/services/profile-sync.ts
+++ b/src/services/profile-sync.ts
@@ -4,6 +4,9 @@ import type { Logger } from '../lib/logger.js'
 import type { Database } from '../db/index.js'
 import { users } from '../db/schema/users.js'
 import { stripControlCharacters } from '../lib/sanitize-text.js'
+import type { LoadedPlugin } from '../lib/plugins/types.js'
+import { executeHook } from '../lib/plugins/runtime.js'
+import { createPluginContext, type CacheAdapter } from '../lib/plugins/context.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -73,6 +76,19 @@ const defaultAgentFactory: AgentFactory = {
 }
 
 // ---------------------------------------------------------------------------
+// Factory options
+// ---------------------------------------------------------------------------
+
+export interface ProfileSyncOptions {
+  agentFactory?: AgentFactory
+  loadedPlugins?: Map<string, LoadedPlugin>
+  enabledPlugins?: Set<string>
+  oauthClient?: unknown
+  cache?: CacheAdapter | null
+  communityDid?: string
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -85,13 +101,21 @@ const defaultAgentFactory: AgentFactory = {
  *
  * @param db - Drizzle database instance
  * @param logger - Pino logger
- * @param agentFactory - Optional factory for creating Agent instances (testing)
+ * @param options - Optional configuration including agent factory and plugin refs
  */
 export function createProfileSyncService(
   db: Database,
   logger: Logger,
-  agentFactory: AgentFactory = defaultAgentFactory
+  options: ProfileSyncOptions = {}
 ): ProfileSyncService {
+  const {
+    agentFactory = defaultAgentFactory,
+    loadedPlugins,
+    enabledPlugins,
+    oauthClient: pluginOauthClient,
+    cache: pluginCache,
+    communityDid: pluginCommunityDid,
+  } = options
   return {
     async syncProfile(did: string): Promise<ProfileData> {
       // 1. Fetch profile from Bluesky public API (no auth needed)
@@ -140,6 +164,41 @@ export function createProfileSyncService(
           .where(eq(users.did, did))
       } catch (err: unknown) {
         logger.warn({ did, err }, 'profile DB update failed: could not persist profile data')
+      }
+
+      // Fire-and-forget plugin onProfileSync hooks
+      if (loadedPlugins && enabledPlugins) {
+        for (const [name, loaded] of loadedPlugins) {
+          if (!enabledPlugins.has(name)) continue
+          if (!loaded.hooks?.onProfileSync) continue
+
+          try {
+            const manifest = loaded.manifest as { permissions?: { backend?: string[] } }
+            const ctx = createPluginContext({
+              pluginName: loaded.name,
+              pluginVersion: loaded.version,
+              permissions: manifest.permissions?.backend ?? [],
+              settings: {},
+              db,
+              cache: pluginCache ?? null,
+              oauthClient: pluginOauthClient ?? null,
+              logger,
+              communityDid: pluginCommunityDid ?? '',
+            })
+            // eslint-disable-next-line @typescript-eslint/unbound-method -- plugin hooks are standalone functions
+            const hookFn = loaded.hooks.onProfileSync as (...args: unknown[]) => Promise<void>
+            void executeHook('onProfileSync', hookFn, ctx, logger, name, did).catch(
+              (err: unknown) => {
+                logger.warn({ err, plugin: name, did }, 'Plugin onProfileSync failed')
+              }
+            )
+          } catch (err: unknown) {
+            logger.warn(
+              { err, plugin: name, did },
+              'Failed to build plugin context for onProfileSync'
+            )
+          }
+        }
       }
 
       return profileData

--- a/tests/unit/lib/plugins/context.test.ts
+++ b/tests/unit/lib/plugins/context.test.ts
@@ -31,6 +31,7 @@ const BASE_OPTIONS: PluginContextOptions = {
   settings: { maxLength: 200, prefix: '--' },
   db: {},
   cache: null,
+  oauthClient: null,
   logger: makeLogger(),
   communityDid: 'did:plc:testcommunity123',
 }
@@ -128,5 +129,47 @@ describe('createPluginContext', () => {
     createPluginContext({ ...BASE_OPTIONS, logger })
 
     expect(childFn).toHaveBeenCalledWith({ plugin: '@barazo/plugin-signatures' })
+  })
+})
+
+describe('ScopedAtProto', () => {
+  it('provides atproto when pds:read permission is present', () => {
+    const ctx = createPluginContext({
+      ...BASE_OPTIONS,
+      permissions: ['pds:read'],
+      oauthClient: {} as never,
+      logger: makeLogger(),
+    })
+    expect(ctx.atproto).toBeDefined()
+  })
+
+  it('provides atproto when pds:write permission is present', () => {
+    const ctx = createPluginContext({
+      ...BASE_OPTIONS,
+      permissions: ['pds:write'],
+      oauthClient: {} as never,
+      logger: makeLogger(),
+    })
+    expect(ctx.atproto).toBeDefined()
+  })
+
+  it('does not provide atproto without pds permissions', () => {
+    const ctx = createPluginContext({
+      ...BASE_OPTIONS,
+      permissions: ['db:write:plugin_signatures'],
+      oauthClient: null,
+      logger: makeLogger(),
+    })
+    expect(ctx.atproto).toBeUndefined()
+  })
+
+  it('does not provide atproto when no oauthClient even with permissions', () => {
+    const ctx = createPluginContext({
+      ...BASE_OPTIONS,
+      permissions: ['pds:read', 'pds:write'],
+      oauthClient: null,
+      logger: makeLogger(),
+    })
+    expect(ctx.atproto).toBeUndefined()
   })
 })

--- a/tests/unit/lib/plugins/runtime.test.ts
+++ b/tests/unit/lib/plugins/runtime.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  resolveHookRef,
+  getPluginShortName,
+  executeHook,
+} from '../../../../src/lib/plugins/runtime.js'
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: 'info',
+  } as never
+}
+
+describe('resolveHookRef', () => {
+  it('parses module path and export name from hook reference', () => {
+    const result = resolveHookRef('./backend/hooks.js#onInstall')
+    expect(result).toEqual({ modulePath: './backend/hooks.js', exportName: 'onInstall' })
+  })
+
+  it('returns null for reference without hash separator', () => {
+    expect(resolveHookRef('./backend/hooks.js')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(resolveHookRef('')).toBeNull()
+  })
+
+  it('handles hash at position 0 as invalid', () => {
+    expect(resolveHookRef('#onInstall')).toBeNull()
+  })
+})
+
+describe('getPluginShortName', () => {
+  it('strips @barazo/plugin- prefix', () => {
+    expect(getPluginShortName('@barazo/plugin-signatures')).toBe('signatures')
+  })
+
+  it('strips barazo-plugin- prefix', () => {
+    expect(getPluginShortName('barazo-plugin-editor')).toBe('editor')
+  })
+
+  it('returns name unchanged if no known prefix', () => {
+    expect(getPluginShortName('some-plugin')).toBe('some-plugin')
+  })
+})
+
+describe('executeHook', () => {
+  it('calls the hook function and returns true on success', async () => {
+    const hook = vi.fn().mockResolvedValue(undefined)
+    const logger = makeLogger()
+    const result = await executeHook('onEnable', hook, {} as never, logger, '@barazo/plugin-test')
+    expect(result).toBe(true)
+    expect(hook).toHaveBeenCalledWith({})
+  })
+
+  it('returns false and logs error when hook throws', async () => {
+    const hook = vi.fn().mockRejectedValue(new Error('boom'))
+    const logger = makeLogger()
+    const result = await executeHook('onEnable', hook, {} as never, logger, '@barazo/plugin-test')
+    expect(result).toBe(false)
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  it('passes extra args to the hook for onProfileSync', async () => {
+    const hook = vi.fn().mockResolvedValue(undefined)
+    const logger = makeLogger()
+    await executeHook(
+      'onProfileSync',
+      hook,
+      {} as never,
+      logger,
+      '@barazo/plugin-test',
+      'did:plc:user1'
+    )
+    expect(hook).toHaveBeenCalledWith({}, 'did:plc:user1')
+  })
+})

--- a/tests/unit/routes/admin-plugins.test.ts
+++ b/tests/unit/routes/admin-plugins.test.ts
@@ -102,6 +102,9 @@ async function buildTestApp(user?: RequestUser): Promise<FastifyInstance> {
   app.decorate('env', mockEnv)
   app.decorate('requireAdmin', requireAdmin as never)
   app.decorate('cache', {} as never)
+  app.decorate('oauthClient', {} as never)
+  app.decorate('loadedPlugins', new Map() as never)
+  app.decorate('enabledPlugins', new Set() as never)
   app.decorateRequest('user', undefined as RequestUser | undefined)
 
   await app.register(adminPluginRoutes())

--- a/tests/unit/services/profile-sync.test.ts
+++ b/tests/unit/services/profile-sync.test.ts
@@ -111,9 +111,11 @@ describe('ProfileSyncService', () => {
     mockDb = createMockDb()
 
     service = createProfileSyncService(mockDb, mockLogger, {
-      createAgent: () => ({
-        getProfile: mockGetProfile,
-      }),
+      agentFactory: {
+        createAgent: () => ({
+          getProfile: mockGetProfile,
+        }),
+      },
     })
   })
 
@@ -251,9 +253,11 @@ describe('ProfileSyncService', () => {
     })
 
     service = createProfileSyncService(mockDb, mockLogger, {
-      createAgent: () => ({
-        getProfile: mockGetProfile,
-      }),
+      agentFactory: {
+        createAgent: () => ({
+          getProfile: mockGetProfile,
+        }),
+      },
     })
 
     const result = await service.syncProfile(TEST_DID)
@@ -287,9 +291,11 @@ describe('ProfileSyncService', () => {
     })
 
     service = createProfileSyncService(mockDb, mockLogger, {
-      createAgent: () => ({
-        getProfile: mockGetProfile,
-      }),
+      agentFactory: {
+        createAgent: () => ({
+          getProfile: mockGetProfile,
+        }),
+      },
     })
 
     await service.syncProfile(TEST_DID)


### PR DESCRIPTION
## Summary

Implements the 4 runtime gaps identified in singi-labs/barazo-workspace#94, unblocking plugin execution end-to-end:

- **Lifecycle hook execution** — `onInstall`/`onUninstall`/`onEnable`/`onDisable` hooks called from admin-plugins routes with proper `PluginContext`
- **PluginContext construction with ScopedAtProto** — public reads via Bluesky public API, authenticated writes via OAuth session restore
- **Plugin route registration** — discovered plugin routes mounted at `/api/ext/<short-name>/` with enabled-check preHandler (returns 404 when disabled)
- **onProfileSync call site** — fire-and-forget hook execution after profile DB update, iterating enabled plugins

### New files
- `src/lib/plugins/runtime.ts` — `resolveHookRef`, `executeHook`, `loadPluginHooks`, `buildLoadedPlugin`
- `tests/unit/lib/plugins/runtime.test.ts` — 10 unit tests

### Key changes
- `ScopedAtProto` interface now takes explicit `did` parameter for `putRecord`/`deleteRecord` (breaking change for plugins — coordinated with barazo-plugins)
- `syncPluginsToDb` returns `{ newPlugins }` to track first-time discovery
- `createProfileSyncService` now accepts `ProfileSyncOptions` object (was positional params)
- Plugin settings and permissions loaded from DB at route registration time

## Test plan

- [x] All 2341 tests pass (120 files)
- [x] ESLint clean
- [x] TypeScript strict mode clean
- [x] Build succeeds
- [ ] CI pipeline passes

Closes singi-labs/barazo-workspace#94