### PR TITLE
fix(docker): resolve broken workspace symlinks in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,13 @@ RUN addgroup --system --gid 1001 nodejs && \
 # Copy production deployment (node_modules + package.json)
 COPY --from=builder /app/deploy/ ./
 
+# Resolve workspace symlink: pnpm deploy creates a symlink for @singi-labs/lexicons
+# that points back to the build workspace (/workspace/barazo-lexicons), which doesn't
+# exist in the runner stage. Replace it with the actual built package.
+RUN rm -f node_modules/@singi-labs/lexicons && rm -f node_modules/@barazo/plugin-signatures
+COPY --from=builder /workspace/barazo-lexicons/ ./node_modules/@singi-labs/lexicons/
+COPY --from=builder /workspace/barazo-plugins/packages/plugin-signatures/ ./node_modules/@barazo/plugin-signatures/
+
 # Copy compiled output
 COPY --from=builder /workspace/barazo-api/dist/ ./dist/
 


### PR DESCRIPTION
## Summary
- `pnpm deploy` creates symlinks for workspace packages (`@singi-labs/lexicons`, `@barazo/plugin-signatures`) pointing to `/workspace/` which doesn't exist in the Docker runner stage
- This caused the API to crash on startup with `ERR_MODULE_NOT_FOUND: Cannot find package '@singi-labs/lexicons'`
- Fix: replace symlinks with actual built packages via explicit `COPY --from=builder` directives

## Root cause
`pnpm deploy --prod` should inject workspace packages when `inject-workspace-packages=true` is set in `.npmrc`, but it creates symlinks instead. The symlinks point back to the builder stage's `/workspace/` directory which is discarded in the multi-stage build.

## Test plan
- [x] Local CI passes (lint, typecheck, build, 2341 tests)
- [ ] CI passes
- [ ] Staging deploys successfully with API container healthy
- [ ] Topics endpoint returns 200 (not 500)