### PR TITLE
fix(docker): deploy workspace packages with resolved dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,18 @@ RUN pnpm --filter @singi-labs/lexicons build && \
 # pnpm deploy copies workspace + prod deps (requires inject-workspace-packages=true in .npmrc).
 RUN pnpm --filter barazo-api deploy /app/deploy --prod
 
+# pnpm deploy creates symlinks for workspace packages that point back to
+# /workspace/, which won't exist in the runner stage. Deploy each workspace
+# package separately (resolves their dependencies), then merge into the
+# API's node_modules.
+RUN pnpm --filter @singi-labs/lexicons deploy /tmp/lexicons-deploy --prod \
+    && pnpm --filter @barazo/plugin-signatures deploy /tmp/sigs-deploy --prod
+
+RUN rm -rf /app/deploy/node_modules/@singi-labs/lexicons \
+    && rm -rf /app/deploy/node_modules/@barazo/plugin-signatures \
+    && cp -r /tmp/lexicons-deploy /app/deploy/node_modules/@singi-labs/lexicons \
+    && cp -r /tmp/sigs-deploy /app/deploy/node_modules/@barazo/plugin-signatures
+
 # ---------------------------------------------------------------------------
 # Stage 3: Production runner
 # ---------------------------------------------------------------------------
@@ -66,13 +78,6 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 # Copy production deployment (node_modules + package.json)
 COPY --from=builder /app/deploy/ ./
-
-# Resolve workspace symlink: pnpm deploy creates a symlink for @singi-labs/lexicons
-# that points back to the build workspace (/workspace/barazo-lexicons), which doesn't
-# exist in the runner stage. Replace it with the actual built package.
-RUN rm -f node_modules/@singi-labs/lexicons && rm -f node_modules/@barazo/plugin-signatures
-COPY --from=builder /workspace/barazo-lexicons/ ./node_modules/@singi-labs/lexicons/
-COPY --from=builder /workspace/barazo-plugins/packages/plugin-signatures/ ./node_modules/@barazo/plugin-signatures/
 
 # Copy compiled output
 COPY --from=builder /workspace/barazo-api/dist/ ./dist/


### PR DESCRIPTION
## Summary
- Previous fix (#152) copied raw workspace directories into the production image, but workspace packages' own dependencies (like `@atproto/lexicon`) are hoisted to the workspace root and weren't included
- This caused `ERR_MODULE_NOT_FOUND: Cannot find package '@atproto/lexicon'` at runtime
- Fix: use `pnpm deploy` for each workspace package separately to get standalone copies with all resolved dependencies, then merge into the API's `node_modules`

## Test plan
- [ ] CI passes
- [ ] Staging deploys with API container healthy
- [ ] `staging.barazo.forum` loads without errors