### PR TITLE
fix(docker): use pnpm deploy for lexicons, direct copy for plugin-signatures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,16 +53,15 @@ RUN pnpm --filter @singi-labs/lexicons build && \
 RUN pnpm --filter barazo-api deploy /app/deploy --prod
 
 # pnpm deploy creates symlinks for workspace packages that point back to
-# /workspace/, which won't exist in the runner stage. Deploy each workspace
-# package separately (resolves their dependencies), then merge into the
-# API's node_modules.
-RUN pnpm --filter @singi-labs/lexicons deploy /tmp/lexicons-deploy --prod \
-    && pnpm --filter @barazo/plugin-signatures deploy /tmp/sigs-deploy --prod
+# /workspace/, which won't exist in the runner stage. Fix each:
+# - lexicons: use pnpm deploy to get package + resolved dependencies
+# - plugin-signatures: only has peerDeps (satisfied by API), copy source directly
+RUN pnpm --filter @singi-labs/lexicons deploy /tmp/lexicons-deploy --prod
 
 RUN rm -rf /app/deploy/node_modules/@singi-labs/lexicons \
-    && rm -rf /app/deploy/node_modules/@barazo/plugin-signatures \
     && cp -r /tmp/lexicons-deploy /app/deploy/node_modules/@singi-labs/lexicons \
-    && cp -r /tmp/sigs-deploy /app/deploy/node_modules/@barazo/plugin-signatures
+    && rm -rf /app/deploy/node_modules/@barazo/plugin-signatures \
+    && cp -r /workspace/barazo-plugins/packages/plugin-signatures /app/deploy/node_modules/@barazo/plugin-signatures
 
 # ---------------------------------------------------------------------------
 # Stage 3: Production runner


### PR DESCRIPTION
## Summary
- Fixes #153's build failure: `pnpm deploy --filter @barazo/plugin-signatures` fails because it's not a pnpm workspace member (nested under `barazo-plugins/`)
- Lexicons: uses `pnpm deploy` to get package + all resolved dependencies
- Plugin-signatures: direct copy since it only has peerDependencies (all satisfied by the API's node_modules)

## Test plan
- [ ] Docker image builds successfully
- [ ] Staging deploys with healthy API container
- [ ] `staging.barazo.forum` loads topics