### PR TITLE
fix(plugins): include dependencies in serialized plugin response

### DIFF
--- a/src/routes/admin-plugins.ts
+++ b/src/routes/admin-plugins.ts
@@ -55,6 +55,7 @@ const pluginListJsonSchema = {
 // ---------------------------------------------------------------------------
 
 function serializePlugin(row: typeof plugins.$inferSelect, settings?: Record<string, unknown>) {
+  const manifest = row.manifestJson as ManifestJson | null
   return {
     id: row.id,
     name: row.name,
@@ -65,6 +66,7 @@ function serializePlugin(row: typeof plugins.$inferSelect, settings?: Record<str
     category: row.category,
     enabled: row.enabled,
     manifestJson: row.manifestJson,
+    dependencies: manifest?.dependencies ?? [],
     settings: settings ?? {},
     installedAt: row.installedAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),


### PR DESCRIPTION
## Summary

- `serializePlugin` was not extracting `dependencies` from `manifestJson`, returning `undefined`
- Frontend crashes with `TypeError: can't access property "length", V.dependencies is undefined` on `/admin/plugins/`
- Now extracts `dependencies` from the stored manifest with `?? []` fallback

Paired with singi-labs/barazo-web fix for defensive optional chaining.

## Test plan

- [x] admin-plugins tests pass (7/7)
- [ ] CI passes