### PR TITLE
fix(docker): copy plugin tsconfig.base.json for tsc build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ COPY --from=deps /workspace/ ./
 COPY barazo-lexicons/ ./barazo-lexicons/
 
 # Copy plugin-signatures source (workspace dependency via link:)
+# Include tsconfig.base.json so the plugin's "extends": "../../tsconfig.base.json" resolves
+COPY barazo-plugins/tsconfig.base.json ./barazo-plugins/
 COPY barazo-plugins/packages/plugin-signatures/ ./barazo-plugins/packages/plugin-signatures/
 
 # Copy API source


### PR DESCRIPTION
## Summary
- Copy `barazo-plugins/tsconfig.base.json` into the Docker build context
- The plugin's `tsconfig.json` extends `../../tsconfig.base.json` but only the plugin subdirectory was copied, so tsc fell back to default settings (no `skipLibCheck`, no `esModuleInterop`)
- This caused hundreds of type errors from `node_modules` during the Docker build stage

## Context
Fourth fix in the staging deploy chain for plugin runtime wiring (#94):
1. ~~Missing `dependencies` field (#155)~~
2. ~~plugin.json dist paths (barazo-plugins#5)~~
3. ~~Workspace glob pattern (barazo-workspace#102 + #103)~~
4. **This PR** — missing tsconfig.base.json in Docker context

Fixes singi-labs/barazo-workspace#94