### PR TITLE
fix(docker): build only plugin backend in API image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY barazo-api/ ./barazo-api/
 
 # Build workspace dependencies first, then API
 RUN pnpm --filter @singi-labs/lexicons build && \
-    pnpm --filter @barazo/plugin-signatures build && \
+    pnpm --filter @barazo/plugin-signatures run build:backend && \
     pnpm --filter barazo-api build
 
 # Create standalone production deployment with resolved dependencies.


### PR DESCRIPTION
## Summary
- Use `build:backend` instead of `build` for `@barazo/plugin-signatures` in the Dockerfile
- The API image only needs plugin backend code (hooks, routes, migrations)
- Frontend components (React TSX) are loaded by barazo-web, not barazo-api

## Context
The full `tsc` build fails in Docker because React types aren't resolvable under `moduleResolution: "NodeNext"` without `@types/react`. Rather than adding unnecessary dependencies, we only compile what the API needs.

Depends on singi-labs/barazo-plugins#6 (adds `build:backend` script).

Fixes singi-labs/barazo-workspace#94