### PR TITLE
fix(plugins): include settingsSchema in serialized plugin response

### DIFF
--- a/src/routes/admin-plugins.ts
+++ b/src/routes/admin-plugins.ts
@@ -67,6 +67,7 @@ function serializePlugin(row: typeof plugins.$inferSelect, settings?: Record<str
     enabled: row.enabled,
     manifestJson: row.manifestJson,
     dependencies: manifest?.dependencies ?? [],
+    settingsSchema: manifest?.settings ?? {},
     settings: settings ?? {},
     installedAt: row.installedAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),


### PR DESCRIPTION
## Summary
- Add `settingsSchema: manifest?.settings ?? {}` to `serializePlugin()`
- The frontend uses `plugin.settingsSchema` for the settings gear icon (`Object.keys()`) and the settings modal (`Object.entries()`), but the API wasn't returning it
- Without this field, the admin plugins page crashes with "can't convert undefined to object"

## Test plan
- [ ] Visit `/admin/plugins/` — page loads without errors
- [ ] Plugin with settings shows gear icon
- [ ] Click gear icon opens settings modal with correct fields