### PR TITLE
fix(plugins): add dependencies and settingsSchema to response schema

### DIFF
--- a/src/routes/admin-plugins.ts
+++ b/src/routes/admin-plugins.ts
@@ -34,6 +34,8 @@ const pluginJsonSchema = {
     category: { type: 'string' as const },
     enabled: { type: 'boolean' as const },
     manifestJson: { type: 'object' as const },
+    dependencies: { type: 'array' as const, items: { type: 'string' as const } },
+    settingsSchema: { type: 'object' as const },
     settings: { type: 'object' as const },
     installedAt: { type: 'string' as const, format: 'date-time' as const },
     updatedAt: { type: 'string' as const, format: 'date-time' as const },


### PR DESCRIPTION
## Summary
- Add `dependencies` and `settingsSchema` to the Fastify response JSON schema
- Fastify uses `fast-json-stringify` which only serializes fields declared in the response schema — undeclared fields are silently dropped
- PR #155 added `dependencies` and #158 added `settingsSchema` to `serializePlugin()`, but both were stripped from the actual HTTP response

## Root cause
The `pluginJsonSchema` (used for `200` responses) didn't declare these fields. Fastify's serializer only outputs fields present in the schema.

## Test plan
- [ ] `GET /api/plugins` response includes `settingsSchema` with setting definitions
- [ ] `GET /api/plugins` response includes `dependencies` array
- [ ] Plugin settings gear icon appears on admin plugins page