### PR TITLE
feat(notifications): respect per-community notification preferences (GH#77)

### DIFF
--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -187,7 +187,12 @@ function defaultCommunityPreferences(communityDid: string) {
     mutedWords: null,
     blockedDids: null,
     mutedDids: null,
-    notificationPrefs: null,
+    notificationPrefs: {
+      replies: false,
+      reactions: false,
+      mentions: true,
+      modActions: false,
+    },
     updatedAt: new Date().toISOString(),
   }
 }

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -1,7 +1,8 @@
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { Database } from '../db/index.js'
 import type { Logger } from '../lib/logger.js'
 import { notifications } from '../db/schema/notifications.js'
+import { userCommunityPreferences } from '../db/schema/user-preferences.js'
 import { topics } from '../db/schema/topics.js'
 import { replies } from '../db/schema/replies.js'
 import { users } from '../db/schema/users.js'
@@ -108,6 +109,43 @@ export interface CrossPostFailureNotificationParams {
 // Helpers
 // ---------------------------------------------------------------------------
 
+type NotificationPrefs = {
+  replies: boolean
+  reactions: boolean
+  mentions: boolean
+  modActions: boolean
+}
+
+/**
+ * Determine whether a notification of a given type should be delivered based on
+ * the recipient's stored preferences.
+ *
+ * Defaults when no preferences are stored:
+ *   - mentions: true (enabled by default)
+ *   - replies, reactions, modActions: false
+ *
+ * mod_action is always delivered regardless of preferences — users must receive
+ * moderation decisions about their content.
+ */
+export function isNotificationAllowed(
+  type: NotificationType,
+  prefs: NotificationPrefs | null | undefined
+): boolean {
+  if (type === 'mod_action') {
+    return true
+  }
+
+  if (!prefs) {
+    return type === 'mention'
+  }
+
+  if (type === 'reply') return prefs.replies
+  if (type === 'reaction') return prefs.reactions
+  if (type === 'mention') return prefs.mentions
+
+  return true
+}
+
 /**
  * Extract unique AT Protocol handles from content text.
  * Returns at most MAX_MENTION_NOTIFICATIONS handles.
@@ -147,6 +185,7 @@ export function createNotificationService(db: Database, logger: Logger): Notific
   /**
    * Insert a single notification row.
    * Skips silently if recipientDid === actorDid (no self-notifications).
+   * Checks per-community notification preferences before inserting.
    */
   async function insertNotification(
     recipientDid: string,
@@ -157,6 +196,23 @@ export function createNotificationService(db: Database, logger: Logger): Notific
   ): Promise<void> {
     if (recipientDid === actorDid) {
       return
+    }
+
+    if (type !== 'mod_action') {
+      const prefRows = await db
+        .select({ notificationPrefs: userCommunityPreferences.notificationPrefs })
+        .from(userCommunityPreferences)
+        .where(
+          and(
+            eq(userCommunityPreferences.did, recipientDid),
+            eq(userCommunityPreferences.communityDid, communityDid)
+          )
+        )
+
+      const prefs = prefRows[0]?.notificationPrefs
+      if (!isNotificationAllowed(type, prefs)) {
+        return
+      }
     }
 
     await db.insert(notifications).values({

--- a/tests/unit/routes/profiles.test.ts
+++ b/tests/unit/routes/profiles.test.ts
@@ -2149,12 +2149,22 @@ describe('profile routes', () => {
         communityDid: string
         maturityOverride: null
         mutedWords: null
-        notificationPrefs: null
+        notificationPrefs: {
+          replies: boolean
+          reactions: boolean
+          mentions: boolean
+          modActions: boolean
+        }
       }>()
       expect(body.communityDid).toBe(COMMUNITY_DID)
       expect(body.maturityOverride).toBeNull()
       expect(body.mutedWords).toBeNull()
-      expect(body.notificationPrefs).toBeNull()
+      expect(body.notificationPrefs).toEqual({
+        replies: false,
+        reactions: false,
+        mentions: true,
+        modActions: false,
+      })
     })
 
     it('returns existing values including non-null fields', async () => {
@@ -2345,12 +2355,22 @@ describe('profile routes', () => {
         mutedWords: null
         blockedDids: null
         mutedDids: null
-        notificationPrefs: null
+        notificationPrefs: {
+          replies: boolean
+          reactions: boolean
+          mentions: boolean
+          modActions: boolean
+        }
       }>()
       expect(body.communityDid).toBe(COMMUNITY_DID)
       expect(body.maturityOverride).toBeNull()
       expect(body.mutedWords).toBeNull()
-      expect(body.notificationPrefs).toBeNull()
+      expect(body.notificationPrefs).toEqual({
+        replies: false,
+        reactions: false,
+        mentions: true,
+        modActions: false,
+      })
     })
 
     it('only sets maturityOverride when only maturityOverride is provided', async () => {

--- a/tests/unit/services/notification.test.ts
+++ b/tests/unit/services/notification.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createNotificationService, extractMentions } from '../../../src/services/notification.js'
+import {
+  createNotificationService,
+  extractMentions,
+  isNotificationAllowed,
+} from '../../../src/services/notification.js'
 import type { NotificationService } from '../../../src/services/notification.js'
 import { createMockDb, createChainableProxy, resetDbMocks } from '../../helpers/mock-db.js'
 import type { MockDb } from '../../helpers/mock-db.js'
@@ -7,6 +11,9 @@ import type { MockDb } from '../../helpers/mock-db.js'
 // ---------------------------------------------------------------------------
 // Test constants
 // ---------------------------------------------------------------------------
+
+const ALLOW_ALL_PREFS = { replies: true, reactions: true, mentions: true, modActions: true }
+const DENY_ALL_PREFS = { replies: false, reactions: false, mentions: false, modActions: false }
 
 const ACTOR_DID = 'did:plc:actor123'
 const TOPIC_AUTHOR_DID = 'did:plc:topicauthor456'
@@ -102,9 +109,10 @@ describe('extractMentions', () => {
 
 describe('notifyOnReply', () => {
   it('notifies topic author when someone replies', async () => {
-    // Mock: select topic author
-    const selectChain = createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }])
-    mockDb.select.mockReturnValue(selectChain)
+    // Mock: select topic author, then prefs (allow replies)
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
 
     // Mock: insert notification
     const insertChain = createChainableProxy()
@@ -142,12 +150,12 @@ describe('notifyOnReply', () => {
   })
 
   it('notifies both topic author and parent reply author for nested replies', async () => {
-    // First select: topic author
-    const topicSelectChain = createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }])
-    // Second select: parent reply author
-    const parentSelectChain = createChainableProxy([{ authorDid: REPLY_AUTHOR_DID }])
-
-    mockDb.select.mockReturnValueOnce(topicSelectChain).mockReturnValueOnce(parentSelectChain)
+    // select: topic author, prefs for topic author, parent reply author, prefs for parent author
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: REPLY_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
 
     const insertChain = createChainableProxy()
     mockDb.insert.mockReturnValue(insertChain)
@@ -166,10 +174,12 @@ describe('notifyOnReply', () => {
 
   it('does not duplicate notification when parent reply author is topic author', async () => {
     // Same author for topic and parent reply
-    const topicSelectChain = createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }])
-    const parentSelectChain = createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }])
-
-    mockDb.select.mockReturnValueOnce(topicSelectChain).mockReturnValueOnce(parentSelectChain)
+    // select: topic author, prefs for topic author, parent reply author (same person, deduplicated)
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+    // No prefs lookup for parent since parentAuthor === topicAuthor (deduplicated before insertNotification)
 
     const insertChain = createChainableProxy()
     mockDb.insert.mockReturnValue(insertChain)
@@ -209,8 +219,10 @@ describe('notifyOnReply', () => {
 
 describe('notifyOnReaction', () => {
   it('notifies topic author when their topic gets a reaction', async () => {
-    const selectChain = createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }])
-    mockDb.select.mockReturnValue(selectChain)
+    // select: topic author, then prefs (allow reactions)
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
 
     const insertChain = createChainableProxy()
     mockDb.insert.mockReturnValue(insertChain)
@@ -225,12 +237,11 @@ describe('notifyOnReaction', () => {
   })
 
   it('notifies reply author when their reply gets a reaction', async () => {
-    // First select (topic lookup): no match
-    const noMatchChain = createChainableProxy([])
-    // Second select (reply lookup): match
-    const replyChain = createChainableProxy([{ authorDid: REPLY_AUTHOR_DID }])
-
-    mockDb.select.mockReturnValueOnce(noMatchChain).mockReturnValueOnce(replyChain)
+    // select: topic lookup (no match), reply lookup (match), then prefs (allow reactions)
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([]))
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: REPLY_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
 
     const insertChain = createChainableProxy()
     mockDb.insert.mockReturnValue(insertChain)
@@ -301,11 +312,12 @@ describe('notifyOnModAction', () => {
 
 describe('notifyOnMentions', () => {
   it('resolves handles to DIDs and creates mention notifications', async () => {
-    // Select: resolve handles
-    const userSelectChain = createChainableProxy([
-      { did: 'did:plc:mentioned1', handle: 'jay.bsky.team' },
-    ])
-    mockDb.select.mockReturnValue(userSelectChain)
+    // select: resolve handles, then prefs for the mentioned user (allow mentions)
+    mockDb.select
+      .mockReturnValueOnce(
+        createChainableProxy([{ did: 'did:plc:mentioned1', handle: 'jay.bsky.team' }])
+      )
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: ALLOW_ALL_PREFS }]))
 
     const insertChain = createChainableProxy()
     mockDb.insert.mockReturnValue(insertChain)
@@ -363,6 +375,169 @@ describe('notifyOnMentions', () => {
     // Should not even query the DB
     expect(mockDb.select).not.toHaveBeenCalled()
     expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+})
+
+// ===========================================================================
+// isNotificationAllowed (pure helper)
+// ===========================================================================
+
+describe('isNotificationAllowed', () => {
+  it('allows reply when prefs.replies is true', () => {
+    expect(isNotificationAllowed('reply', { ...DENY_ALL_PREFS, replies: true })).toBe(true)
+  })
+
+  it('denies reply when prefs.replies is false', () => {
+    expect(isNotificationAllowed('reply', { ...ALLOW_ALL_PREFS, replies: false })).toBe(false)
+  })
+
+  it('allows reaction when prefs.reactions is true', () => {
+    expect(isNotificationAllowed('reaction', { ...DENY_ALL_PREFS, reactions: true })).toBe(true)
+  })
+
+  it('denies reaction when prefs.reactions is false', () => {
+    expect(isNotificationAllowed('reaction', { ...ALLOW_ALL_PREFS, reactions: false })).toBe(false)
+  })
+
+  it('allows mention when prefs.mentions is true', () => {
+    expect(isNotificationAllowed('mention', { ...DENY_ALL_PREFS, mentions: true })).toBe(true)
+  })
+
+  it('denies mention when prefs.mentions is false', () => {
+    expect(isNotificationAllowed('mention', { ...ALLOW_ALL_PREFS, mentions: false })).toBe(false)
+  })
+
+  it('defaults to mentions=true when prefs are null', () => {
+    expect(isNotificationAllowed('mention', null)).toBe(true)
+  })
+
+  it('defaults to replies=false when prefs are null', () => {
+    expect(isNotificationAllowed('reply', null)).toBe(false)
+  })
+
+  it('defaults to reactions=false when prefs are null', () => {
+    expect(isNotificationAllowed('reaction', null)).toBe(false)
+  })
+
+  it('mod_action is always allowed regardless of prefs', () => {
+    expect(isNotificationAllowed('mod_action', DENY_ALL_PREFS)).toBe(true)
+    expect(isNotificationAllowed('mod_action', null)).toBe(true)
+  })
+})
+
+// ===========================================================================
+// Preference-based filtering (integration with notification service)
+// ===========================================================================
+
+describe('notification preference filtering', () => {
+  it('suppresses reply notification when replies preference is disabled', async () => {
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: { ...DENY_ALL_PREFS } }]))
+
+    const insertChain = createChainableProxy()
+    mockDb.insert.mockReturnValue(insertChain)
+
+    await service.notifyOnReply({
+      replyUri: REPLY_URI,
+      actorDid: ACTOR_DID,
+      topicUri: TOPIC_URI,
+      parentUri: TOPIC_URI,
+      communityDid: COMMUNITY_DID,
+    })
+
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it('suppresses reaction notification when reactions preference is disabled', async () => {
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: { ...DENY_ALL_PREFS } }]))
+
+    const insertChain = createChainableProxy()
+    mockDb.insert.mockReturnValue(insertChain)
+
+    await service.notifyOnReaction({
+      subjectUri: TOPIC_URI,
+      actorDid: ACTOR_DID,
+      communityDid: COMMUNITY_DID,
+    })
+
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it('suppresses mention notification when mentions preference is disabled', async () => {
+    mockDb.select
+      .mockReturnValueOnce(
+        createChainableProxy([{ did: 'did:plc:mentioned1', handle: 'jay.bsky.team' }])
+      )
+      .mockReturnValueOnce(createChainableProxy([{ notificationPrefs: { ...DENY_ALL_PREFS } }]))
+
+    const insertChain = createChainableProxy()
+    mockDb.insert.mockReturnValue(insertChain)
+
+    await service.notifyOnMentions({
+      content: 'Hey @jay.bsky.team',
+      subjectUri: REPLY_URI,
+      actorDid: ACTOR_DID,
+      communityDid: COMMUNITY_DID,
+    })
+
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it('sends reply notification when no prefs exist and default allows it (no row)', async () => {
+    // No prefs row found → default: replies=false, so no notification
+    mockDb.select
+      .mockReturnValueOnce(createChainableProxy([{ authorDid: TOPIC_AUTHOR_DID }]))
+      .mockReturnValueOnce(createChainableProxy([])) // empty → no prefs row
+
+    await service.notifyOnReply({
+      replyUri: REPLY_URI,
+      actorDid: ACTOR_DID,
+      topicUri: TOPIC_URI,
+      parentUri: TOPIC_URI,
+      communityDid: COMMUNITY_DID,
+    })
+
+    expect(mockDb.insert).not.toHaveBeenCalled()
+  })
+
+  it('sends mention notification when no prefs exist (default: mentions=true)', async () => {
+    // No prefs row → default: mentions=true → notification is sent
+    mockDb.select
+      .mockReturnValueOnce(
+        createChainableProxy([{ did: 'did:plc:mentioned1', handle: 'jay.bsky.team' }])
+      )
+      .mockReturnValueOnce(createChainableProxy([])) // empty → no prefs row
+
+    const insertChain = createChainableProxy()
+    mockDb.insert.mockReturnValue(insertChain)
+
+    await service.notifyOnMentions({
+      content: 'Hey @jay.bsky.team',
+      subjectUri: REPLY_URI,
+      actorDid: ACTOR_DID,
+      communityDid: COMMUNITY_DID,
+    })
+
+    expect(mockDb.insert).toHaveBeenCalled()
+  })
+
+  it('always delivers mod_action notification regardless of preferences', async () => {
+    const insertChain = createChainableProxy()
+    mockDb.insert.mockReturnValue(insertChain)
+
+    await service.notifyOnModAction({
+      targetUri: TOPIC_URI,
+      moderatorDid: MODERATOR_DID,
+      targetDid: TOPIC_AUTHOR_DID,
+      communityDid: COMMUNITY_DID,
+    })
+
+    // No prefs lookup, insert always called
+    expect(mockDb.select).not.toHaveBeenCalled()
+    expect(mockDb.insert).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary

- Adds per-community notification preference filtering to `insertNotification` in `src/services/notification.ts`
- Exports `isNotificationAllowed` pure helper — checks stored `notificationPrefs` JSONB against the notification type
- Default when no preferences row exists: `mentions: true`, `replies/reactions/modActions: false` (per spec)
- `mod_action` notifications are always delivered regardless of preferences
- Updates `defaultCommunityPreferences()` in `src/routes/profiles.ts` to return the explicit spec defaults instead of `null`

## What changed

No schema migration needed — `notificationPrefs` JSONB column already exists in `user_community_preferences`. The `GET/PUT /api/users/me/preferences/communities/:did` endpoints already accept and persist the notification fields.

The only missing piece was the notification service respecting those stored preferences, which this PR adds.

## Test plan

- [x] 13 new unit tests covering: `isNotificationAllowed` pure logic, suppression when prefs disabled, default mention-enabled behaviour, mod_action bypass
- [x] Updated existing reply/reaction/mention tests to mock the additional prefs `SELECT`
- [x] Updated profiles route tests to expect new `defaultCommunityPreferences()` shape
- [x] `pnpm vitest run tests/unit/services/notification.test.ts tests/unit/routes/profiles.test.ts` — 135 tests pass
- [x] TypeScript: no errors in changed files

Fixes singi-labs/barazo-workspace#77 (partial — frontend wire-up follows in a separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)